### PR TITLE
Adding alltoall

### DIFF
--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -105,6 +105,7 @@ int main(int argc, char **argv)
     int sys_cores_per_node = 1;
     std::string metadata;
     const char *warmup_region = "warmup";
+    const char *warmup_region_aa = "warmup_aa";
 
     int opt;
     const char *usage =
@@ -182,6 +183,10 @@ int main(int argc, char **argv)
                                CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
     cali_id_t message_size_attr = cali_create_attribute("message_size_bytes",
                                   CALI_TYPE_INT, CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t comm_phase_attr = cali_create_attribute("comm_phase", CALI_TYPE_STRING,
+                            CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t iter_time_sec_attr = cali_create_attribute("iter_time_sec", CALI_TYPE_DOUBLE
+                               CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
 
     const char *src_dest_attributes = R"json(
         {
@@ -199,7 +204,11 @@ int main(int argc, char **argv)
                 {"expr": "any(max#dest_rank)", "as": "dest_rank"},
                 {"expr": "any(max#src_node)", "as": "src_node"},
                 {"expr": "any(max#dest_node)", "as": "dest_node"},
-                {"expr": "any(max#message_size_bytes)", "as": "message_size_bytes"}
+                {"expr": "any(max#message_size_bytes)", "as": "message_size_bytes"},
+                {"expr": "any(max#comm_phase)", "as" : "comm_phase"},
+                {"expr": "avg(iter_time_sec)", "as" : "iter_avg_s"},
+                {"expr": "max(iter_time_sec)", "as" : "iter_max_s"},
+                {"expr": "min(iter_time_sec)", "as" : "iter_min_s"}
                 ]
             },
             {
@@ -210,7 +219,11 @@ int main(int argc, char **argv)
                 {"expr": "any(any#max#dest_rank)", "as": "dest_rank"},
                 {"expr": "any(any#max#src_node)", "as": "src_node"},
                 {"expr": "any(any#max#dest_node)", "as": "dest_node"},
-                {"expr": "any(any#max#message_size_bytes)", "as": "message_size_bytes"}
+                {"expr": "any(any#max#message_size_bytes)", "as": "message_size_bytes"},
+                {"expr": "any(any#max#comm_phase)", "as": "comm_phase"},
+                {"expr": "avg(iter_time_sec)", "as" : "iter_avg_s"},
+                {"expr": "max(iter_time_sec)", "as" : "iter_max_s"},
+                {"expr": "min(iter_time_sec)", "as" : "iter_min_s"}
                 ]
             }
             ]
@@ -411,6 +424,10 @@ int main(int argc, char **argv)
 #endif
                     double rtt = end - start;
                     total_time += rtt;
+#if defined(USE_CALIPER)
+                    cali_set_string(comm_phase_attr, "pingpong");
+                    cali_set_double(iter_time_sec_attr, total_time);
+#endif
                 }
                 else if (rank == partner_rank)
                 {
@@ -429,7 +446,6 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
             CALI_MARK_END(region_label.c_str());
 #endif
-
 #if defined(USE_HIP)
             hipFree(send_buf);
             hipFree(recv_buf);
@@ -443,6 +459,130 @@ int main(int argc, char **argv)
             free(recv_buf);
 #endif
         }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        size_t aa_bytes_per_rank = static_cast<size_t>(message);
+        size_t aa_total_bytes = aa_bytes_per_rank * static_cast<size_t>(size);
+
+#if defined(USE_HIP)
+        char *aa_send_buf;
+        char *aa_recv_buf;
+
+        hipError_t a_err1 = hipMalloc((void**)&aa_send_buf, aa_total_bytes);
+        hipError_t a_err2 = hipMalloc((void**)&aa_recv_buf, aa_total_bytes);
+
+        if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
+            fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+
+        hipError_t a_cuerr1 = hipMemset(aa_send_buf, 'a', aa_total_bytes);
+        assert(a_cuerr1 == hipSuccess);
+        hipError_t a_cuerr2 = hipMemset(aa_recv_buf, 0, aa_total_bytes);
+        assert(a_cuerr2 == hipSuccess);
+
+#elif defined(USE_CUDA)
+        int a_dev_count = 0;
+        cuda_check(cudaGetDeviceCount(&a_dev_count));
+        cuda_check(cudaSetDevice(rank % (a_dev_count > 0 ? a_dev_count : 1)));
+
+        char *ad_send = nullptr;
+        char *ad_recv = nullptr;
+        cuda_check(cudaMalloc((void**)&ad_send, aa_total_bytes));
+        cuda_check(cudaMalloc((void**)&ad_recv, aa_total_bytes));
+        cuda_check(cudaMemset(ad_send, 'a', aa_total_bytes));
+        cuda_check(cudaMemset(ad_recv, 0, aa_total_bytes));
+
+        char *ah_send = nullptr;
+        char *ah_recv = nullptr;
+        cuda_check(cudaMallocHost((void**)&ah_send, aa_total_bytes));
+        cuda_check(cudaMallocHost((void**)&ah_recv, aa_total_bytes));
+        memset(ah_send, 'a', aa_total_bytes);
+        memset(ah_recv, 0, aa_total_bytes);
+#else
+        char *aa_send = (char*) malloc(aa_total_bytes);
+        char *aa_recv = (char*) malloc(aa_total_bytes);
+        memset(aa_send, 'b', aa_total_bytes);
+        memset(aa_recv,  0, aa_total_bytes);
+#endif
+
+#if defined(USE_CALIPER)
+            CALI_MARK_BEGIN(warmup_region_aa);
+#endif
+
+        for (int i = 0; i < warmup; i++)
+        {
+#if defined(USE_HIP)
+            hipMemcpy(aa_send_dev, aa_send_host, aa_total_bytes, hipMemcpyHostToDevice);
+            hipDeviceSynchronize();
+            MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+            hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+            hipDeviceSynchronize();
+#elif defined(USE_CUDA)
+            cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
+            MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+            cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
+#else
+            MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+#endif
+        }
+
+#if defined(USE_CALIPER)
+            CALI_MARK_END(warmup_region_aa);
+            CALI_MARK_BEGIN(region_label.c_str());
+#endif
+
+        for (int it = 0; it < PING_PONG_LIMIT; ++it) {
+            MPI_Barrier(MPI_COMM_WORLD); // sync before each timed iter
+
+            double t0 = MPI_Wtime();
+
+#if defined(USE_HIP)
+            hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+            MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+            hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+            hipDeviceSynchronize();
+#elif defined(USE_CUDA)
+            cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
+            MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+            cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
+#else
+            MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+#endif
+
+            double t1 = MPI_Wtime();
+            double dt = t1 - t0;
+
+            double iter_max = 0.0;
+            MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+            if (rank == 0)
+            {
+                alltoall_total_max += iter_max;
+#if defined(USE_CALIPER)
+                cali_set_string(comm_phase_attr, "alltoall");
+                cali_set_double(iter_time_sec_attr, alltoall_total_time);
+#endif
+            }
+        }
+#if defined(USE_CALIPER)
+            CALI_MARK_END(region_label.c_str());
+#endif
+
+#if defined(USE_HIP)
+        free(aa_send_host);
+        free(aa_recv_host);
+        hipFree(aa_send_dev);
+        hipFree(aa_recv_dev);
+#elif defined(USE_CUDA)
+        cuda_check(cudaFreeHost(ah_send));
+        cuda_check(cudaFreeHost(ah_recv));
+        cuda_check(cudaFree(ad_send));
+        cuda_check(cudaFree(ad_recv));
+#else
+        free(aa_send);
+        free(aa_recv);
+#endif
 
 #if defined(USE_CALIPER)
         mgr[message].stop();

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -27,7 +27,7 @@
 #define CALI_MARK_END
 #endif
 
-#if defined(USE_ROCM)
+#if defined(USE_HIP)
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 #endif
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
             double total_time = 0.0;
             int warmup = 1;
 
-#if defined(USE_ROCM)
+#if defined(USE_HIP)
             char *send_buf;
             char *recv_buf;
 
@@ -355,7 +355,7 @@ int main(int argc, char **argv)
             {
                 if (rank == 0)
                 {
-#if defined(USE_ROCM)
+#if defined(USE_HIP)
                     MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
                     MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD,
                              MPI_STATUS_IGNORE);
@@ -371,7 +371,7 @@ int main(int argc, char **argv)
                 }
                 else if (rank == partner_rank)
                 {
-#if defined(USE_ROCM)
+#if defined(USE_HIP)
                     MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
                     MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 #elif defined(USE_CUDA)
@@ -430,7 +430,7 @@ int main(int argc, char **argv)
             CALI_MARK_END(region_label.c_str());
 #endif
 
-#if defined(USE_ROCM)
+#if defined(USE_HIP)
             hipFree(send_buf);
             hipFree(recv_buf);
 #elif defined(USE_CUDA)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -183,10 +183,8 @@ int main(int argc, char **argv)
                                CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
     cali_id_t message_size_attr = cali_create_attribute("message_size_bytes",
                                   CALI_TYPE_INT, CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t comm_phase_attr = cali_create_attribute("comm_phase", CALI_TYPE_STRING,
-                            CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t iter_time_sec_attr = cali_create_attribute("iter_time_sec", CALI_TYPE_DOUBLE
-                               CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t comm_phase_attr = cali_create_attribute("comm_phase", CALI_TYPE_STRING, CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t iter_time_sec_attr = cali_create_attribute("iter_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
 
     const char *src_dest_attributes = R"json(
         {
@@ -458,10 +456,10 @@ int main(int argc, char **argv)
             free(send_buf);
             free(recv_buf);
 #endif
-        }
 
+//------------------------------------------------------------------------------------------------------------------------------------------------
         MPI_Barrier(MPI_COMM_WORLD);
-
+//------------------------------------------------------------------------------------------------------------------------------------------------
         size_t aa_bytes_per_rank = static_cast<size_t>(message);
         size_t aa_total_bytes = aa_bytes_per_rank * static_cast<size_t>(size);
 
@@ -583,6 +581,10 @@ int main(int argc, char **argv)
         free(aa_send);
         free(aa_recv);
 #endif
+
+        }
+
+        
 
 #if defined(USE_CALIPER)
         mgr[message].stop();

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -625,3 +625,4 @@ int main(int argc, char **argv)
         MPI_Finalize();
         return 0;
     }
+}

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <limits>
 #include <assert.h>
+#include <limits.h>
 
 #if defined(USE_CALIPER)
 #include <caliper/cali.h>
@@ -768,7 +769,7 @@ int main(int argc, char **argv)
             double rtt_max = 0.0;
             int iters = 0;
 
-            for(int i  0; i < PING_PONG_LIMIT; i++)
+            for(int i = 0; i < PING_PONG_LIMIT; i++)
             {
                 MPI_Barrier(MPI_COMM_WORLD);
                 double t0 = MPI_Wtime();
@@ -835,6 +836,8 @@ int main(int argc, char **argv)
 
         for (int partner_rank : partners)
         {
+            std::string region_label = region_names[partner_rank];
+            
             size_t ar_count = static_cast<size_t>(message);
             if (ar_count > INT_MAX) {
                 if (rank == 0) fprintf(stderr, "Allreduce count too large\n");
@@ -910,7 +913,7 @@ int main(int argc, char **argv)
             double rtt_max = 0.0;
             int iters = 0;
 
-            for(int i  0; i < PING_PONG_LIMIT; i++)
+            for(int i = 0; i < PING_PONG_LIMIT; i++)
             {
                 MPI_Barrier(MPI_COMM_WORLD);
                 double t0 = MPI_Wtime();

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -765,8 +765,8 @@ int main(int argc, char **argv)
             CALI_MARK_BEGIN(region_label.c_str());
 #endif
 
-            double rtt_min = std::numeric_limits<double>::infinity();
-            double rtt_max = 0.0;
+            double min_rtt = std::numeric_limits<double>::infinity();
+            double max_rtt = 0.0;
             int iters = 0;
 
             for(int i = 0; i < PING_PONG_LIMIT; i++)
@@ -797,7 +797,7 @@ int main(int argc, char **argv)
 
                     double avg_rtt = 0.0;
                     if(iters > 0){
-                    avg_rtt = alltoall_total_time / iters;
+                    avg_rtt = red_total_time / iters;
                     } else {
                         avg_rtt = 0.0;
                     }
@@ -909,8 +909,8 @@ int main(int argc, char **argv)
             CALI_MARK_END(warmup_region_ar);
             CALI_MARK_BEGIN(region_label.c_str());
 #endif
-            double rtt_min = std::numeric_limits<double>::infinity();
-            double rtt_max = 0.0;
+            double min_rtt = std::numeric_limits<double>::infinity();
+            double max_rtt = 0.0;
             int iters = 0;
 
             for(int i = 0; i < PING_PONG_LIMIT; i++)
@@ -941,7 +941,7 @@ int main(int argc, char **argv)
 
                     double avg_rtt = 0.0;
                     if(iters > 0){
-                    avg_rtt = red_total_time / iters;
+                    avg_rtt = ar_total_time / iters;
                     } else {
                         avg_rtt = 0.0;
                     }

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -970,23 +970,22 @@ int main(int argc, char **argv)
 #endif
         }
 
-
 #if defined(USE_CALIPER)
         mgr[message].stop();
 #endif
+    }
 
 #if defined(USE_CALIPER)
-        if (rank == 0 && !all_comm_pairs.empty())
-        {
-            adiak::value("all_comm_pairs", all_comm_pairs);
-        }
-        for (auto &m : mgr)
-        {
-            m.second.flush();
-        }
+    if (rank == 0 && !all_comm_pairs.empty())
+    {
+        adiak::value("all_comm_pairs", all_comm_pairs);
+    }
+    for (auto &m : mgr)
+    {
+        m.second.flush();
+    }
 #endif
 
-        MPI_Finalize();
-        return 0;
-    }
+    MPI_Finalize();
+    return 0;
 }

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -463,7 +463,7 @@ int main(int argc, char **argv)
                 }
             }
 
-            if(rank = 0)
+            if(rank == 0)
             {
                 double avg_rtt = 0.0;
                 if(iters > 0){

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -317,6 +317,7 @@ int main(int argc, char **argv)
 
             double total_time = 0.0;
             int warmup = 1;
+            double alltoall_total_time = 0.0;
 
 #if defined(USE_HIP)
             char *send_buf;
@@ -556,7 +557,7 @@ int main(int argc, char **argv)
             MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
             if (rank == 0)
             {
-                alltoall_total_max += iter_max;
+                alltoall_total_time += iter_max;
 #if defined(USE_CALIPER)
                 cali_set_string(comm_phase_attr, "alltoall");
                 cali_set_double(iter_time_sec_attr, alltoall_total_time);

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -24,8 +24,8 @@
 
 #ifndef USE_CALIPER
 #define CALI_CXX_MARK_FUNCTION
-#define CALI_MARK_BEGIN
-#define CALI_MARK_END
+#define CALI_MARK_BEGIN(x)
+#define CALI_MARK_END(x)
 #endif
 
 #if defined(USE_HIP)
@@ -44,40 +44,35 @@ inline void cuda_check(cudaError_t e) {
 #endif
 
 const char *get_hostname_for_rank(int rank, char all_hostnames[][1024],
-                                  int size)
-{
-    if (rank >= 0 && rank < size)
-    {
-        return all_hostnames[rank];
-    }
-    else
-    {
-        return "INVALID_RANK";
-    }
+                                  int size) {
+    if (rank >= 0 && rank < size) return all_hostnames[rank];
+    return "INVALID_RANK";
 }
 
-int extract_node_number(const char *hostname)
-{
+int extract_node_number(const char *hostname) {
     int len = strlen(hostname);
     int num = 0;
     int factor = 1;
-    for (int i = len - 1; i >= 0; --i)
-    {
-        if (hostname[i] >= '0' && hostname[i] <= '9')
-        {
+    for (int i = len - 1; i >= 0; --i) {
+        if (hostname[i] >= '0' && hostname[i] <= '9') {
             num += (hostname[i] - '0') * factor;
             factor *= 10;
-        }
-        else
-        {
-            break;
-        }
+        } else break;
     }
     return num;
 }
 
-int main(int argc, char **argv)
-{
+// Make a prefix subcommunicator: ranks [0..active_size-1]
+static MPI_Comm make_prefix_subcomm(int active_size) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    int color = (rank < active_size) ? 1 : MPI_UNDEFINED;
+    MPI_Comm sub = MPI_COMM_NULL;
+    MPI_Comm_split(MPI_COMM_WORLD, color, rank, &sub);
+    return sub;
+}
+
+int main(int argc, char **argv) {
     int rank, size;
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -105,9 +100,9 @@ int main(int argc, char **argv)
     int sys_cores_per_socket = 1;
     int sys_cores_per_node = 1;
     std::string metadata;
-    const char *warmup_region = "warmup";
+    const char *warmup_region    = "warmup";
     const char *warmup_region_aa = "warmup_aa";
-    const char *warmup_region_red = "warmup_red";
+    const char *warmup_region_red= "warmup_red";
     const char *warmup_region_ar = "warmup_ar";
 
     int opt;
@@ -115,41 +110,26 @@ int main(int argc, char **argv)
         "Usage: %s [-h] [-i n-iterations] [-p rank1,rank2] [-m msg_sz] "
         "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] [-b metadata]\n";
 
-    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:")) != -1)
-    {
-        switch (opt)
-        {
+    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:")) != -1) {
+        switch (opt) {
             case 'h':
-                printf(usage, argv[0]);
+                if (rank==0) printf(usage, argv[0]);
+                MPI_Finalize();
                 return 0;
-            case 'i':
-                PING_PONG_LIMIT = atoi(optarg);
-                break;
-            case 'p':
-                break;
-            case 'm':
-                msg_size = atoi(optarg);
-                break;
-            case 'n':
-                n_nodes = atoi(optarg);
-                break;
-            case 's':
-                sys_cores_per_socket = atoi(optarg);
-                break;
-            case 'c':
-                sys_cores_per_node = atoi(optarg);
-                break;
-            case 'b':
-                metadata = optarg;
-                break;
+            case 'i': PING_PONG_LIMIT = atoi(optarg); break;
+            case 'p': break;
+            case 'm': msg_size = atoi(optarg); break;
+            case 'n': n_nodes = atoi(optarg); break;
+            case 's': sys_cores_per_socket = atoi(optarg); break;
+            case 'c': sys_cores_per_node = atoi(optarg); break;
+            case 'b': metadata = optarg; break;
             default:
-                printf(usage, argv[0]);
-                exit(EXIT_FAILURE);
+                if (rank==0) printf(usage, argv[0]);
+                MPI_Abort(MPI_COMM_WORLD, 1);
         }
     }
 
-    if (rank == 0)
-    {
+    if (rank == 0) {
         printf("Configuration:\n");
         printf("PING_PONG_LIMIT: %d\n", PING_PONG_LIMIT);
         printf("Message size: %d bytes\n", msg_size);
@@ -161,13 +141,9 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
         std::stringstream rankmap;
         rankmap << "{";
-        for (int i = 0; i < size; ++i)
-        {
+        for (int i = 0; i < size; ++i) {
             rankmap << "\"" << i << "\": \"" << all_hostnames[i] << "\"";
-            if (i < size - 1)
-            {
-                rankmap << ", ";
-            }
+            if (i < size - 1) rankmap << ", ";
         }
         rankmap << "}";
         adiak::value("rank_node_map", rankmap.str());
@@ -230,6 +206,7 @@ int main(int argc, char **argv)
                 {"expr": "any(max#src_node)", "as": "src_node"},
                 {"expr": "any(max#dest_node)", "as": "dest_node"},
                 {"expr": "any(max#message_size_bytes)", "as": "message_size_bytes"},
+                {"expr": "any(max#comm_phase)", "as" : "comm_phase"},
                 {"expr": "any(max#aa_avg_time_sec)", "as" : "aa_avg_s"},
                 {"expr": "any(max#aa_max_time_sec)", "as" : "aa_max_s"},
                 {"expr": "any(max#aa_min_time_sec)", "as" : "aa_min_s"},
@@ -243,7 +220,7 @@ int main(int argc, char **argv)
                 {"expr": "any(max#ar_max_time_sec)", "as" : "ar_max_s"},
                 {"expr": "any(max#ar_min_time_sec)", "as" : "ar_min_s"}
                 ],
-                "group by": ["comm_phase"],
+                "group by": ["comm_phase"]
             },
             {
                 "level": "cross",
@@ -254,6 +231,7 @@ int main(int argc, char **argv)
                 {"expr": "any(any#max#src_node)", "as": "src_node"},
                 {"expr": "any(any#max#dest_node)", "as": "dest_node"},
                 {"expr": "any(any#max#message_size_bytes)", "as": "message_size_bytes"},
+                {"expr": "any(any#max#comm_phase)", "as" : "comm_phase"},
                 {"expr": "any(any#max#aa_avg_time_sec)", "as" : "aa_avg_s"},
                 {"expr": "any(any#max#aa_max_time_sec)", "as" : "aa_max_s"},
                 {"expr": "any(any#max#aa_min_time_sec)", "as" : "aa_min_s"},
@@ -267,11 +245,11 @@ int main(int argc, char **argv)
                 {"expr": "any(any#max#ar_max_time_sec)", "as" : "ar_max_s"},
                 {"expr": "any(any#max#ar_min_time_sec)", "as" : "ar_min_s"}
                 ],
-                "group by": ["comm_phase"],
+                "group by": ["comm_phase"]
             }
             ]
         }
-        )json";
+    )json";
 #endif
 
     auto now = std::chrono::system_clock::now();
@@ -286,45 +264,41 @@ int main(int argc, char **argv)
     int current_nodes = n_nodes;
     int current_p = P;
 
-    while (current_p > 2)
-    {
+    while (current_p > 2) {
         int partner_rank = current_p - 1;
         std::string label;
-        if (current_nodes >= 2)
-        {
-            label = std::to_string(current_nodes) + " nodes";
-        }
-        else
-        {
-            label = "Same Node Different Socket";
-        }
+        if (current_nodes >= 2) label = std::to_string(current_nodes) + " nodes";
+        else label = "Same Node Different Socket";
 
-        if (partner_rank > 0 && partner_rank < size)
-        {
+        if (partner_rank > 0 && partner_rank < size) {
             partners.push_back(partner_rank);
             region_names[partner_rank] = label;
         }
         current_nodes = current_nodes / 2;
         current_p = current_nodes * sys_cores_per_node;
     }
-
-    // Always add same node same socket as 0 <-> 1
-    if (1 < size)
-    {
+    if (1 < size) {
         partners.push_back(1);
         region_names[1] = "Same Node Same Socket";
     }
 
-    for (int message = msg_size; message <= pow(msg_size, 6); message *= 8)
-    {
+    // Build “buckets” (active prefix sizes) for collectives
+    std::vector<int> buckets;
+    // same-node/same-socket (2) if possible
+    if (size >= 2) buckets.push_back(2);
+    for (int nodes = 2; nodes <= n_nodes; nodes *= 2) {
+        int active = nodes * sys_cores_per_node;
+        if (active <= size) buckets.push_back(active);
+    }
+
+    for (int message = msg_size; message <= (int)std::pow((double)msg_size, 6.0); message *= 8) {
 #if defined(USE_CALIPER)
         std::string profile = "spot(output=" + std::to_string(message) + "_" +
                               timestamp.str() +
-                              ".cali, profile.mpi),metadata(file=" + metadata +
-                              "),metadata(file=/etc/node_info.json,keys=\"host.os\")";
-
+                              ".cali, profile.mpi)"
+                              + (metadata.empty() ? "" : (",metadata(file=" + metadata + ")")) +
+                              ",metadata(file=/etc/node_info.json,keys=\"host.os\")";
         cali_set_int(message_size_attr, message);
-
         mgr[message].add_option_spec(src_dest_attributes);
         mgr[message].set_default_parameter("pingpong_attributes", "true");
         adiak::value("message_size", message);
@@ -332,27 +306,21 @@ int main(int argc, char **argv)
         mgr[message].start();
 #endif
 
-        for (int partner_rank : partners)
-        {
+        // ------------------------- PINGPONG (WORLD) -------------------------
+        for (int partner_rank : partners) {
             std::string region_label = region_names[partner_rank];
 
-            if (rank != 0 && rank != partner_rank)
-            {
-                continue;
-            }
+            if (rank != 0 && rank != partner_rank) continue;
 
-            if (rank == 0)
-            {
-                printf("\n--- Testing %s between ranks 0 (%s) and %d (%s) ---\n",
+            if (rank == 0) {
+                printf("\n--- Testing %s between ranks 0 (%s) and %d (%s), msg=%d ---\n",
                        region_label.c_str(),
-                       all_hostnames[0], partner_rank, all_hostnames[partner_rank]);
-
+                       all_hostnames[0], partner_rank, all_hostnames[partner_rank], message);
 #if defined(USE_CALIPER)
                 std::string comm_pair = "0(" + std::string(all_hostnames[0]) + ")<->" +
                                         std::to_string(partner_rank) + "(" + std::string(all_hostnames[partner_rank]) +
                                         ")";
                 all_comm_pairs.push_back(comm_pair);
-
                 cali_set_int(src_rank_attr, 0);
                 cali_set_int(dest_rank_attr, partner_rank);
                 cali_set_int(src_node_attr, extract_node_number(all_hostnames[0]));
@@ -360,39 +328,27 @@ int main(int argc, char **argv)
 #endif
             }
 
-//PINGPONG
-
             double total_time = 0.0;
             int warmup = 1;
 
 #if defined(USE_HIP)
-            char *send_buf;
-            char *recv_buf;
-
+            char *send_buf;   char *recv_buf;
             hipError_t err1 = hipMalloc((void**)&send_buf, message);
             hipError_t err2 = hipMalloc((void**)&recv_buf, message);
-
             if (err1 != hipSuccess || err2 != hipSuccess) {
                 fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(err1), hipGetErrorString(err2));
                 MPI_Abort(MPI_COMM_WORLD, 1);
             }
-
-            hipError_t cuerr1 = hipMemset(send_buf, 'a', message);
-            assert(cuerr1 == hipSuccess);
-            hipError_t cuerr2 = hipMemset(recv_buf, 0, message);
-            assert(cuerr2 == hipSuccess);
+            hipError_t cuerr1 = hipMemset(send_buf, 'a', message); assert(cuerr1 == hipSuccess);
+            hipError_t cuerr2 = hipMemset(recv_buf, 0, message);   assert(cuerr2 == hipSuccess);
 #elif defined(USE_CUDA)
-            int dev_count = 0;
-            cuda_check(cudaGetDeviceCount(&dev_count));
+            int dev_count = 0; cuda_check(cudaGetDeviceCount(&dev_count));
             cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
-
-            char *d_send = nullptr;
-            char *d_recv = nullptr;
+            char *d_send = nullptr; char *d_recv = nullptr;
             cuda_check(cudaMalloc((void**)&d_send, message));
             cuda_check(cudaMalloc((void**)&d_recv, message));
             cuda_check(cudaMemset(d_send, 'a', message));
             cuda_check(cudaMemset(d_recv, 0, message));
-
             char *h_send = nullptr, *h_recv = nullptr;
             cuda_check(cudaMallocHost((void**)&h_send, message));
             cuda_check(cudaMallocHost((void**)&h_recv, message));
@@ -405,18 +361,12 @@ int main(int argc, char **argv)
             memset(recv_buf, 0, message);
 #endif
 
-#if defined(USE_CALIPER)
             CALI_MARK_BEGIN(warmup_region);
-#endif
-
-            for (int i = 0; i < warmup; i++)
-            {
-                if (rank == 0)
-                {
+            for (int i = 0; i < warmup; i++) {
+                if (rank == 0) {
 #if defined(USE_HIP)
                     MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                    MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD,
-                             MPI_STATUS_IGNORE);
+                    MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 #elif defined(USE_CUDA)
                     cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
                     MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
@@ -426,9 +376,7 @@ int main(int argc, char **argv)
                     MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
                     MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 #endif
-                }
-                else if (rank == partner_rank)
-                {
+                } else if (rank == partner_rank) {
 #if defined(USE_HIP)
                     MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
                     MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
@@ -443,19 +391,15 @@ int main(int argc, char **argv)
 #endif
                 }
             }
-
-#if defined(USE_CALIPER)
             CALI_MARK_END(warmup_region);
+
             CALI_MARK_BEGIN(region_label.c_str());
-#endif
             double min_rtt = std::numeric_limits<double>::infinity();
             double max_rtt = 0.0;
             int iters = 0;
 
-            for (int i = 0; i < PING_PONG_LIMIT; i++)
-            {
-                if (rank == 0)
-                {
+            for (int i = 0; i < PING_PONG_LIMIT; i++) {
+                if (rank == 0) {
 #if defined(USE_CUDA)
                     double start = MPI_Wtime();
                     cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
@@ -466,20 +410,15 @@ int main(int argc, char **argv)
 #else
                     double start = MPI_Wtime();
                     MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                    MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD,
-                             MPI_STATUS_IGNORE);
+                    MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
                     double end = MPI_Wtime();
 #endif
                     double rtt = end - start;
                     total_time += rtt;
-                    
-                    if(rtt < min_rtt) min_rtt = rtt;
-                    if(rtt > max_rtt) max_rtt = rtt;
+                    if (rtt < min_rtt) min_rtt = rtt;
+                    if (rtt > max_rtt) max_rtt = rtt;
                     ++iters;
-
-                }
-                else if (rank == partner_rank)
-                {
+                } else if (rank == partner_rank) {
 #if defined(USE_CUDA)
                     MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
                     cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
@@ -492,14 +431,8 @@ int main(int argc, char **argv)
                 }
             }
 
-            if(rank == 0)
-            {
-                double avg_rtt = 0.0;
-                if(iters > 0){
-                    avg_rtt = total_time / iters;
-                } else {
-                    avg_rtt = 0.0;
-                }
+            if (rank == 0) {
+                double avg_rtt = (iters > 0) ? total_time / iters : 0.0;
 #if defined(USE_CALIPER)
                 cali_set_string(comm_phase_attr, "pingpong");
                 cali_set_double(pp_avg_time_sec_attr, avg_rtt);
@@ -507,152 +440,118 @@ int main(int argc, char **argv)
                 cali_set_double(pp_min_time_sec_attr, min_rtt);
 #endif
             }
-
-#if defined(USE_CALIPER)
             CALI_MARK_END(region_label.c_str());
-#endif
+
 #if defined(USE_HIP)
-            hipFree(send_buf);
-            hipFree(recv_buf);
+            hipFree(send_buf); hipFree(recv_buf);
 #elif defined(USE_CUDA)
-            cuda_check(cudaFreeHost(h_send));
-            cuda_check(cudaFreeHost(h_recv));
-            cuda_check(cudaFree(d_send));
-            cuda_check(cudaFree(d_recv));
+            cuda_check(cudaFreeHost(h_send)); cuda_check(cudaFreeHost(h_recv));
+            cuda_check(cudaFree(d_send));     cuda_check(cudaFree(d_recv));
 #else
-            free(send_buf);
-            free(recv_buf);
+            free(send_buf); free(recv_buf);
 #endif
         }
 
-//------------------------------------------------------------------------------------------------------------------------------------------------
+        // keep everyone aligned before starting collectives
         MPI_Barrier(MPI_COMM_WORLD);
-//------------------------------------------------------------------------------------------------------------------------------------------------
-//ALLTOALL
-        for (int partner_rank : partners)
-        {
-            std::string region_label = region_names[partner_rank];
+
+        // ------------------------- ALLTOALL (SUBCOMMS) -------------------------
+        for (int active_size : buckets) {
+            std::string region_label = "Alltoall_" + std::to_string(active_size);
+            MPI_Comm sub = make_prefix_subcomm(active_size);
+            int sub_rank=-1, sub_size=0;
+            if (sub != MPI_COMM_NULL) { MPI_Comm_rank(sub,&sub_rank); MPI_Comm_size(sub,&sub_size); }
 
             size_t aa_bytes_per_rank = static_cast<size_t>(message);
-            size_t aa_total_bytes = aa_bytes_per_rank * static_cast<size_t>(size);
-
+            size_t aa_total_bytes = aa_bytes_per_rank * static_cast<size_t>((sub==MPI_COMM_NULL)?0:sub_size);
             int warmup = 1;
             double alltoall_total_time = 0.0;
-
-#if defined(USE_HIP)
-            char *aa_send_dev;
-            char *aa_recv_dev;
-
-            hipError_t a_err1 = hipMalloc((void**)&aa_send_dev, aa_total_bytes);
-            hipError_t a_err2 = hipMalloc((void**)&aa_recv_dev, aa_total_bytes);
-
-            if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
-                fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
-                MPI_Abort(MPI_COMM_WORLD, 1);
-            }
-
-            hipError_t a_cuerr1 = hipMemset(aa_send_dev, 'a', aa_total_bytes);
-            assert(a_cuerr1 == hipSuccess);
-            hipError_t a_cuerr2 = hipMemset(aa_recv_dev, 0, aa_total_bytes);
-            assert(a_cuerr2 == hipSuccess);
-
-            char *aa_send_host = (char*) malloc(aa_total_bytes);
-            char *aa_recv_host = (char*) malloc(aa_total_bytes);
-            memset(aa_send_host, 'a', aa_total_bytes);
-            memset(aa_recv_host, 0, aa_total_bytes);
-
-#elif defined(USE_CUDA)
-            int a_dev_count = 0;
-            cuda_check(cudaGetDeviceCount(&a_dev_count));
-            cuda_check(cudaSetDevice(rank % (a_dev_count > 0 ? a_dev_count : 1)));
-
-            char *ad_send = nullptr;
-            char *ad_recv = nullptr;
-            cuda_check(cudaMalloc((void**)&ad_send, aa_total_bytes));
-            cuda_check(cudaMalloc((void**)&ad_recv, aa_total_bytes));
-            cuda_check(cudaMemset(ad_send, 'a', aa_total_bytes));
-            cuda_check(cudaMemset(ad_recv, 0, aa_total_bytes));
-
-            char *ah_send = nullptr;
-            char *ah_recv = nullptr;
-            cuda_check(cudaMallocHost((void**)&ah_send, aa_total_bytes));
-            cuda_check(cudaMallocHost((void**)&ah_recv, aa_total_bytes));
-            memset(ah_send, 'a', aa_total_bytes);
-            memset(ah_recv, 0, aa_total_bytes);
-#else
-            char *aa_send = (char*) malloc(aa_total_bytes);
-            char *aa_recv = (char*) malloc(aa_total_bytes);
-            memset(aa_send, 'b', aa_total_bytes);
-            memset(aa_recv,  0, aa_total_bytes);
-#endif
-
-#if defined(USE_CALIPER)
-            CALI_MARK_BEGIN(warmup_region_aa);
-#endif
-
-            for (int i = 0; i < warmup; i++)
-            {
-#if defined(USE_HIP)
-                hipMemcpy(aa_send_dev, aa_send_host, aa_total_bytes, hipMemcpyHostToDevice);
-                hipDeviceSynchronize();
-                MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
-                hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
-                hipDeviceSynchronize();
-#elif defined(USE_CUDA)
-                cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
-                MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
-#else
-                MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
-#endif
-            }
-
-#if defined(USE_CALIPER)
-            CALI_MARK_END(warmup_region_aa);
-            CALI_MARK_BEGIN(region_label.c_str());
-#endif
-
             double min_rtt = std::numeric_limits<double>::infinity();
             double max_rtt = 0.0;
             int iters = 0;
 
-            for (int it = 0; it < PING_PONG_LIMIT; ++it)
-            {
-                MPI_Barrier(MPI_COMM_WORLD);
-
-                double t0 = MPI_Wtime();
-
+            if (sub != MPI_COMM_NULL) {
 #if defined(USE_HIP)
-                hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
-                MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
-                hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
-                hipDeviceSynchronize();
+                char *aa_send_dev; char *aa_recv_dev;
+                hipMalloc((void**)&aa_send_dev, aa_total_bytes);
+                hipMalloc((void**)&aa_recv_dev, aa_total_bytes);
+                hipMemset(aa_send_dev, 'a', aa_total_bytes);
+                hipMemset(aa_recv_dev, 0,   aa_total_bytes);
+                char *aa_send_host = (char*) malloc(aa_total_bytes);
+                char *aa_recv_host = (char*) malloc(aa_total_bytes);
+                memset(aa_send_host, 'a', aa_total_bytes);
+                memset(aa_recv_host, 0,   aa_total_bytes);
 #elif defined(USE_CUDA)
-                cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
-                MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
+                int a_dev_count=0; cuda_check(cudaGetDeviceCount(&a_dev_count));
+                cuda_check(cudaSetDevice(rank % (a_dev_count>0 ? a_dev_count : 1)));
+                char *ad_send=nullptr, *ad_recv=nullptr;
+                cuda_check(cudaMalloc((void**)&ad_send, aa_total_bytes));
+                cuda_check(cudaMalloc((void**)&ad_recv, aa_total_bytes));
+                cuda_check(cudaMemset(ad_send,'a',aa_total_bytes));
+                cuda_check(cudaMemset(ad_recv,0,  aa_total_bytes));
+                char *ah_send=nullptr, *ah_recv=nullptr;
+                cuda_check(cudaMallocHost((void**)&ah_send, aa_total_bytes));
+                cuda_check(cudaMallocHost((void**)&ah_recv, aa_total_bytes));
+                memset(ah_send,'a',aa_total_bytes);
+                memset(ah_recv,0,  aa_total_bytes);
 #else
-                MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                char *aa_send = (char*) malloc(aa_total_bytes);
+                char *aa_recv = (char*) malloc(aa_total_bytes);
+                memset(aa_send, 'b', aa_total_bytes);
+                memset(aa_recv,  0, aa_total_bytes);
 #endif
 
-                double t1 = MPI_Wtime();
-                double dt = t1 - t0;
+                CALI_MARK_BEGIN(warmup_region_aa);
+                for (int i = 0; i < warmup; i++) {
+#if defined(USE_HIP)
+                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR,
+                                 aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, sub);
+                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+#elif defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
+                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR,
+                                 ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
+                    cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
+#else
+                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR,
+                                 aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
+#endif
+                }
+                CALI_MARK_END(warmup_region_aa);
 
-                double iter_max = 0.0;
-                MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
-                if (rank == 0)
-                {
-                    alltoall_total_time += iter_max;
-                    if(dt < min_rtt) min_rtt = dt;
-                    if(dt > max_rtt) max_rtt = dt;
-                    ++iters;
-
-                    double avg_rtt = 0.0;
-                    if(iters > 0){
-                    avg_rtt = alltoall_total_time / iters;
-                    } else {
-                        avg_rtt = 0.0;
+                CALI_MARK_BEGIN(region_label.c_str());
+                for (int it = 0; it < PING_PONG_LIMIT; ++it) {
+                    MPI_Barrier(sub);
+                    double t0 = MPI_Wtime();
+#if defined(USE_HIP)
+                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR,
+                                 aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, sub);
+                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+#elif defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
+                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR,
+                                 ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
+                    cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
+#else
+                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR,
+                                 aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
+#endif
+                    double dt = MPI_Wtime() - t0;
+                    double iter_max = 0.0;
+                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, sub);
+                    if (sub_rank == 0) {
+                        alltoall_total_time += iter_max;
+                        if (dt < min_rtt) min_rtt = dt;
+                        if (dt > max_rtt) max_rtt = dt;
+                        ++iters;
                     }
+                }
+                CALI_MARK_END(region_label.c_str());
+
+                if (sub_rank == 0) {
+                    double avg_rtt = (iters > 0) ? alltoall_total_time / iters : 0.0;
 #if defined(USE_CALIPER)
                     cali_set_string(comm_phase_attr, "alltoall");
                     cali_set_double(aa_avg_time_sec_attr, avg_rtt);
@@ -660,147 +559,114 @@ int main(int argc, char **argv)
                     cali_set_double(aa_min_time_sec_attr, min_rtt);
 #endif
                 }
-            }
-#if defined(USE_CALIPER)
-            CALI_MARK_END(region_label.c_str());
-#endif
 
 #if defined(USE_HIP)
-            free(aa_send_host);
-            free(aa_recv_host);
-            hipFree(aa_send_dev);
-            hipFree(aa_recv_dev);
+                free(aa_send_host); free(aa_recv_host);
+                hipFree(aa_send_dev); hipFree(aa_recv_dev);
 #elif defined(USE_CUDA)
-            cuda_check(cudaFreeHost(ah_send));
-            cuda_check(cudaFreeHost(ah_recv));
-            cuda_check(cudaFree(ad_send));
-            cuda_check(cudaFree(ad_recv));
+                cuda_check(cudaFreeHost(ah_send)); cuda_check(cudaFreeHost(ah_recv));
+                cuda_check(cudaFree(ad_send)); cuda_check(cudaFree(ad_recv));
 #else
-            free(aa_send);
-            free(aa_recv);
+                free(aa_send); free(aa_recv);
 #endif
+            }
+            if (sub != MPI_COMM_NULL) MPI_Comm_free(&sub);
+
+            MPI_Barrier(MPI_COMM_WORLD);
         }
 
-//------------------------------------------------------------------------------------------------------------------------------------------------
-        MPI_Barrier(MPI_COMM_WORLD);
-//------------------------------------------------------------------------------------------------------------------------------------------------
-//REDUCE
-
-        for (int partner_rank : partners)
-        {
-            std::string region_label = region_names[partner_rank];
+        // ------------------------- REDUCE (SUBCOMMS) -------------------------
+        for (int active_size : buckets) {
+            std::string region_label = "Reduce_" + std::to_string(active_size);
+            MPI_Comm sub = make_prefix_subcomm(active_size);
+            int sub_rank=-1, sub_size=0;
+            if (sub != MPI_COMM_NULL) { MPI_Comm_rank(sub,&sub_rank); MPI_Comm_size(sub,&sub_size); }
 
             size_t red_count = static_cast<size_t>(message);
             if (red_count > INT_MAX) {
                 if (rank == 0) fprintf(stderr, "Reduce count too large\n");
                 MPI_Abort(MPI_COMM_WORLD, 1);
             }
-
             int warmup = 1;
             double red_total_time = 0.0;
-
-#if defined(USE_CUDA)
-            char *rd_d_send=nullptr;
-            char *rd_d_recv=nullptr;
-
-            cuda_check(cudaMalloc((void**)&rd_d_send, red_count));
-            cuda_check(cudaMalloc((void**)&rd_d_recv, red_count));
-            cuda_check(cudaMemset(rd_d_send, 'r', red_count));
-            cuda_check(cudaMemset(rd_d_recv, 0,   red_count));
-
-            char *rd_h_send=nullptr;
-            char *rd_h_recv=nullptr;
-            cuda_check(cudaMallocHost((void**)&rd_h_send, red_count));
-            cuda_check(cudaMallocHost((void**)&rd_h_recv, red_count));
-            memset(rd_h_send, 'r', red_count);
-            memset(rd_h_recv, 0,   red_count);
-#elif defined(USE_HIP)
-            char *rd_d_send=nullptr;
-            char *rd_d_recv=nullptr;
-
-            hipError_t a_err1 = hipMalloc((void**)&rd_d_send, red_count);
-            hipError_t a_err2 = hipMalloc((void**)&rd_d_recv, red_count);
-
-            if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
-                fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
-                MPI_Abort(MPI_COMM_WORLD, 1);
-            }
-
-            hipError_t a_cuerr1 = hipMemset(rd_d_send, 'a', red_count);
-            assert(a_cuerr1 == hipSuccess);
-            hipError_t a_cuerr2 = hipMemset(rd_d_recv, 0, red_count);
-            assert(a_cuerr2 == hipSuccess);
-
-            char *rd_h_send = (char*)malloc(red_count);
-            char *rd_h_recv = (char*)malloc(red_count);
-            memset(rd_h_send, 'r', red_count);
-            memset(rd_h_recv, 0,   red_count);
-#else
-            char *rd_send = (char*)malloc(red_count);
-            char *rd_recv = (char*)malloc(red_count);
-            memset(rd_send, 'r', red_count);
-            memset(rd_recv, 0,   red_count);
-#endif
-
-#if defined(USE_CALIPER)
-            CALI_MARK_BEGIN(warmup_region_red);
-#endif
-            for (int i = 0; i < warmup; i++)
-            {
-#if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
-                MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
-                MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
-                hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
-#else
-                MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
-#endif
-            }
-
-#if defined(USE_CALIPER)
-            CALI_MARK_END(warmup_region_red);
-            CALI_MARK_BEGIN(region_label.c_str());
-#endif
-
             double min_rtt = std::numeric_limits<double>::infinity();
             double max_rtt = 0.0;
             int iters = 0;
 
-            for(int i = 0; i < PING_PONG_LIMIT; i++)
-            {
-                MPI_Barrier(MPI_COMM_WORLD);
-                double t0 = MPI_Wtime();
+            if (sub != MPI_COMM_NULL) {
 #if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
-                MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
+                char *rd_d_send=nullptr, *rd_d_recv=nullptr;
+                cuda_check(cudaMalloc((void**)&rd_d_send, red_count));
+                cuda_check(cudaMalloc((void**)&rd_d_recv, red_count));
+                cuda_check(cudaMemset(rd_d_send, 'r', red_count));
+                cuda_check(cudaMemset(rd_d_recv, 0,   red_count));
+                char *rd_h_send=nullptr, *rd_h_recv=nullptr;
+                cuda_check(cudaMallocHost((void**)&rd_h_send, red_count));
+                cuda_check(cudaMallocHost((void**)&rd_h_recv, red_count));
+                memset(rd_h_send, 'r', red_count);
+                memset(rd_h_recv, 0,   red_count);
 #elif defined(USE_HIP)
-                hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
-                MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
-                hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+                char *rd_d_send=nullptr, *rd_d_recv=nullptr;
+                hipMalloc((void**)&rd_d_send, red_count);
+                hipMalloc((void**)&rd_d_recv, red_count);
+                hipMemset(rd_d_send, 'r', red_count);
+                hipMemset(rd_d_recv, 0,   red_count);
+                char *rd_h_send=(char*)malloc(red_count);
+                char *rd_h_recv=(char*)malloc(red_count);
+                memset(rd_h_send, 'r', red_count);
+                memset(rd_h_recv, 0,   red_count);
 #else
-                MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                char *rd_send=(char*)malloc(red_count);
+                char *rd_recv=(char*)malloc(red_count);
+                memset(rd_send, 'r', red_count);
+                memset(rd_recv, 0,   red_count);
 #endif
-                double dt = MPI_Wtime() - t0;
-                double iter_max = 0.0;
-                MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
 
-                if(rank == 0)
-                {
-                    red_total_time += iter_max;
-                    if(dt < min_rtt) min_rtt = dt;
-                    if(dt > max_rtt) max_rtt = dt;
-                    ++iters;
+                CALI_MARK_BEGIN(warmup_region_red);
+                for (int i = 0; i < warmup; i++) {
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
+                    cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
+                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
+#endif
+                }
+                CALI_MARK_END(warmup_region_red);
 
-                    double avg_rtt = 0.0;
-                    if(iters > 0){
-                    avg_rtt = red_total_time / iters;
-                    } else {
-                        avg_rtt = 0.0;
+                CALI_MARK_BEGIN(region_label.c_str());
+                for (int i = 0; i < PING_PONG_LIMIT; i++) {
+                    MPI_Barrier(sub);
+                    double t0 = MPI_Wtime();
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
+                    cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
+                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
+#endif
+                    double dt = MPI_Wtime() - t0;
+                    double iter_max = 0.0;
+                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, sub);
+                    if (sub_rank == 0) {
+                        red_total_time += iter_max;
+                        if (dt < min_rtt) min_rtt = dt;
+                        if (dt > max_rtt) max_rtt = dt;
+                        ++iters;
                     }
+                }
+                CALI_MARK_END(region_label.c_str());
+
+                if (sub_rank == 0) {
+                    double avg_rtt = (iters > 0) ? red_total_time / iters : 0.0;
 #if defined(USE_CALIPER)
                     cali_set_string(comm_phase_attr, "reduce");
                     cali_set_double(red_avg_time_sec_attr, avg_rtt);
@@ -808,36 +674,31 @@ int main(int argc, char **argv)
                     cali_set_double(red_min_time_sec_attr, min_rtt);
 #endif
                 }
-            }
-#if defined(USE_CALIPER)
-            CALI_MARK_END(region_label.c_str());
-#endif
 
 #if defined(USE_HIP)
-            free(rd_h_send);
-            free(rd_h_recv);
-            hipFree(rd_d_send);
-            hipFree(rd_d_recv);
+                free(rd_h_send); free(rd_h_recv);
+                hipFree(rd_d_send); hipFree(rd_d_recv);
 #elif defined(USE_CUDA)
-            cuda_check(cudaFreeHost(rd_h_send));
-            cuda_check(cudaFreeHost(rd_h_recv));
-            cuda_check(cudaFree(rd_d_send));
-            cuda_check(cudaFree(rd_d_recv));
+                cuda_check(cudaFreeHost(rd_h_send));
+                cuda_check(cudaFreeHost(rd_h_recv));
+                cuda_check(cudaFree(rd_d_send));
+                cuda_check(cudaFree(rd_d_recv));
 #else
-            free(rd_send);
-            free(rd_recv);
+                free(rd_send); free(rd_recv);
 #endif
+            }
+            if (sub != MPI_COMM_NULL) MPI_Comm_free(&sub);
+
+            MPI_Barrier(MPI_COMM_WORLD);
         }
 
-//------------------------------------------------------------------------------------------------------------------------------------------------
-        MPI_Barrier(MPI_COMM_WORLD);
-//------------------------------------------------------------------------------------------------------------------------------------------------
-//ALLREDUCE
+        // ------------------------- ALLREDUCE (SUBCOMMS) -------------------------
+        for (int active_size : buckets) {
+            std::string region_label = "Allreduce_" + std::to_string(active_size);
+            MPI_Comm sub = make_prefix_subcomm(active_size);
+            int sub_rank=-1, sub_size=0;
+            if (sub != MPI_COMM_NULL) { MPI_Comm_rank(sub,&sub_rank); MPI_Comm_size(sub,&sub_size); }
 
-        for (int partner_rank : partners)
-        {
-            std::string region_label = region_names[partner_rank];
-            
             size_t ar_count = static_cast<size_t>(message);
             if (ar_count > INT_MAX) {
                 if (rank == 0) fprintf(stderr, "Allreduce count too large\n");
@@ -845,106 +706,84 @@ int main(int argc, char **argv)
             }
             int warmup = 1;
             double ar_total_time = 0.0;
-
-#if defined(USE_CUDA)
-            char *ar_d_send=nullptr;
-            char *ar_d_recv=nullptr;
-            cuda_check(cudaMalloc((void**)&ar_d_send, ar_count));
-            cuda_check(cudaMalloc((void**)&ar_d_recv, ar_count));
-            cuda_check(cudaMemset(ar_d_send, 'a', ar_count));
-            cuda_check(cudaMemset(ar_d_recv, 0,   ar_count));
-
-            char *ar_h_send=nullptr;
-            char *ar_h_recv=nullptr;
-            cuda_check(cudaMallocHost((void**)&ar_h_send, ar_count));
-            cuda_check(cudaMallocHost((void**)&ar_h_recv, ar_count));
-            memset(ar_h_send, 'a', ar_count);
-            memset(ar_h_recv, 0,   ar_count);
-#elif defined(USE_HIP)
-            char *ar_d_send=nullptr;
-            char *ar_d_recv=nullptr;
-
-            hipError_t a_err1 = hipMalloc((void**)&ar_d_send, ar_count);
-            hipError_t a_err2 = hipMalloc((void**)&ar_d_recv, ar_count);
-
-            if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
-                fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
-                MPI_Abort(MPI_COMM_WORLD, 1);
-            }
-
-            hipError_t a_cuerr1 = hipMemset(ar_d_send, 'a', ar_count);
-            assert(a_cuerr1 == hipSuccess);
-            hipError_t a_cuerr2 = hipMemset(ar_d_recv, 0, ar_count);
-            assert(a_cuerr2 == hipSuccess);
-
-            char *ar_h_send = (char*)malloc(ar_count);
-            char *ar_h_recv = (char*)malloc(ar_count);
-            memset(ar_h_send, 'a', ar_count);
-            memset(ar_h_recv, 0,   ar_count);
-#else
-            char *ar_send = (char*)malloc(ar_count);
-            char *ar_recv = (char*)malloc(ar_count);
-            memset(ar_send, 'a', ar_count);
-            memset(ar_recv, 0,   ar_count);
-#endif
-
-#if defined(USE_CALIPER)
-            CALI_MARK_BEGIN(warmup_region_ar);
-#endif
-            for (int i = 0; i < warmup; i++)
-            {
-#if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
-                MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
-                MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
-                hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
-#else
-                MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
-#endif               
-            }
-#if defined(USE_CALIPER)
-            CALI_MARK_END(warmup_region_ar);
-            CALI_MARK_BEGIN(region_label.c_str());
-#endif
             double min_rtt = std::numeric_limits<double>::infinity();
             double max_rtt = 0.0;
             int iters = 0;
 
-            for(int i = 0; i < PING_PONG_LIMIT; i++)
-            {
-                MPI_Barrier(MPI_COMM_WORLD);
-                double t0 = MPI_Wtime();
+            if (sub != MPI_COMM_NULL) {
 #if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
-                MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
+                char *ar_d_send=nullptr; char *ar_d_recv=nullptr;
+                cuda_check(cudaMalloc((void**)&ar_d_send, ar_count));
+                cuda_check(cudaMalloc((void**)&ar_d_recv, ar_count));
+                cuda_check(cudaMemset(ar_d_send, 'a', ar_count));
+                cuda_check(cudaMemset(ar_d_recv, 0,   ar_count));
+                char *ar_h_send=nullptr; char *ar_h_recv=nullptr;
+                cuda_check(cudaMallocHost((void**)&ar_h_send, ar_count));
+                cuda_check(cudaMallocHost((void**)&ar_h_recv, ar_count));
+                memset(ar_h_send, 'a', ar_count);
+                memset(ar_h_recv, 0,   ar_count);
 #elif defined(USE_HIP)
-                hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
-                MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
-                hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+                char *ar_d_send=nullptr; char *ar_d_recv=nullptr;
+                hipMalloc((void**)&ar_d_send, ar_count);
+                hipMalloc((void**)&ar_d_recv, ar_count);
+                hipMemset(ar_d_send, 'a', ar_count);
+                hipMemset(ar_d_recv, 0,   ar_count);
+                char *ar_h_send=(char*)malloc(ar_count);
+                char *ar_h_recv=(char*)malloc(ar_count);
+                memset(ar_h_send, 'a', ar_count);
+                memset(ar_h_recv, 0,   ar_count);
 #else
-                MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                char *ar_send=(char*)malloc(ar_count);
+                char *ar_recv=(char*)malloc(ar_count);
+                memset(ar_send, 'a', ar_count);
+                memset(ar_recv, 0,   ar_count);
 #endif
-                double dt = MPI_Wtime() - t0;
-                double iter_max = 0.0;
-                MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
 
-                if(rank == 0)
-                {
-                    ar_total_time += iter_max;
-                    if(dt < min_rtt) min_rtt = dt;
-                    if(dt > max_rtt) max_rtt = dt;
-                    ++iters;
+                CALI_MARK_BEGIN(warmup_region_ar);
+                for (int i = 0; i < warmup; i++) {
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
+                    cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
+                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
+#endif
+                }
+                CALI_MARK_END(warmup_region_ar);
 
-                    double avg_rtt = 0.0;
-                    if(iters > 0){
-                    avg_rtt = ar_total_time / iters;
-                    } else {
-                        avg_rtt = 0.0;
+                CALI_MARK_BEGIN(region_label.c_str());
+                for (int i = 0; i < PING_PONG_LIMIT; i++) {
+                    MPI_Barrier(sub);
+                    double t0 = MPI_Wtime();
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
+                    cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
+                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
+#endif
+                    double dt = MPI_Wtime() - t0;
+                    double iter_max = 0.0;
+                    MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, sub);
+                    if (sub_rank == 0) {
+                        ar_total_time += iter_max;
+                        if (dt < min_rtt) min_rtt = dt;
+                        if (dt > max_rtt) max_rtt = dt;
+                        ++iters;
                     }
+                }
+                CALI_MARK_END(region_label.c_str());
+
+                if (sub_rank == 0) {
+                    double avg_rtt = (iters > 0) ? ar_total_time / iters : 0.0;
 #if defined(USE_CALIPER)
                     cali_set_string(comm_phase_attr, "allreduce");
                     cali_set_double(ar_avg_time_sec_attr, avg_rtt);
@@ -952,39 +791,33 @@ int main(int argc, char **argv)
                     cali_set_double(ar_min_time_sec_attr, min_rtt);
 #endif
                 }
-            }
-#if defined(USE_CALIPER)
-            CALI_MARK_END(region_label.c_str());
-#endif
 
 #if defined(USE_HIP)
-            free(ar_h_send);
-            free(ar_h_recv);
-            hipFree(ar_d_send);
-            hipFree(ar_d_recv);
+                free(ar_h_send); free(ar_h_recv);
+                hipFree(ar_d_send); hipFree(ar_d_recv);
 #elif defined(USE_CUDA)
-            cuda_check(cudaFreeHost(ar_h_send));
-            cuda_check(cudaFreeHost(ar_h_recv));
-            cuda_check(cudaFree(ar_d_send));
-            cuda_check(cudaFree(ar_d_recv));
+                cuda_check(cudaFreeHost(ar_h_send)); cuda_check(cudaFreeHost(ar_h_recv));
+                cuda_check(cudaFree(ar_d_send));     cuda_check(cudaFree(ar_d_recv));
 #else
-            free(ar_send);
-            free(ar_recv);
+                free(ar_send); free(ar_recv);
 #endif
+            }
+            if (sub != MPI_COMM_NULL) MPI_Comm_free(&sub);
+
+            MPI_Barrier(MPI_COMM_WORLD);
         }
 
 #if defined(USE_CALIPER)
         mgr[message].stop();
 #endif
+        MPI_Barrier(MPI_COMM_WORLD); // sync before next message size
     }
 
 #if defined(USE_CALIPER)
-    if (rank == 0 && !all_comm_pairs.empty())
-    {
+    if (rank == 0 && !all_comm_pairs.empty()) {
         adiak::value("all_comm_pairs", all_comm_pairs);
     }
-    for (auto &m : mgr)
-    {
+    for (auto &m : mgr) {
         m.second.flush();
     }
 #endif

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -190,9 +190,9 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
     std::vector<std::string> all_comm_pairs;
     static std::map<int, cali::ConfigManager> mgr;
-    MPI_Comm adiak_comm = MPI_COMM_WORLD;
-    adiak::init(&adiak_comm);
-    adiak::collect_all();
+    //MPI_Comm adiak_comm = MPI_COMM_WORLD;
+    //adiak::init(&adiak_comm);
+    //adiak::collect_all();
     CALI_CXX_MARK_FUNCTION;
 #endif
 
@@ -298,9 +298,9 @@ int main(int argc, char **argv)
                 rankmap << ", ";
         }
         rankmap << "}";
-        adiak::value("rank_node_map", rankmap.str());
-        adiak::value("iterations", num_iterations);
-        adiak::value("pingpong_num_pairs", pingpong_num_pairs);
+        //adiak::value("rank_node_map", rankmap.str());
+        //adiak::value("iterations", num_iterations);
+        //adiak::value("pingpong_num_pairs", pingpong_num_pairs);
 #endif
     }
 
@@ -452,7 +452,7 @@ int main(int argc, char **argv)
 
         mgr[message].add_option_spec(src_dest_attributes);
         mgr[message].set_default_parameter("pingpong_attributes", "true");
-        adiak::value("message_size", message);
+        //adiak::value("message_size", message);
         mgr[message].add(profile.c_str());
         mgr[message].start();
 #endif
@@ -1250,7 +1250,7 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
     if (rank == 0 && !all_comm_pairs.empty())
     {
-        adiak::value("all_comm_pairs", all_comm_pairs);
+        //adiak::value("all_comm_pairs", all_comm_pairs);
     }
     for (auto &m : mgr)
     {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -47,8 +47,7 @@ inline void cuda_check(cudaError_t e) {
 // ---- Operation selector (default: PingPong) ----
 enum class OpKind { All, PingPong, Alltoall, Reduce, Allreduce };
 
-const char *get_hostname_for_rank(int rank, char all_hostnames[][1024],
-                                  int size)
+const char *get_hostname_for_rank(int rank, char all_hostnames[][1024], int size)
 {
     if (rank >= 0 && rank < size)
         return all_hostnames[rank];
@@ -58,7 +57,7 @@ const char *get_hostname_for_rank(int rank, char all_hostnames[][1024],
 
 int extract_node_number(const char *hostname)
 {
-    int len = strlen(hostname);
+    int len = (int)strlen(hostname);
     int num = 0;
     int factor = 1;
     for (int i = len - 1; i >= 0; --i)
@@ -465,7 +464,8 @@ int main(int argc, char **argv)
                     build_pingpong_pairs(region_label,
                                          size,
                                          sys_cores_per_socket,
-                                         sys_cores_per_node, pingpong_num_pairs);
+                                         sys_cores_per_node,
+                                         pingpong_num_pairs);
 
                 if (pairs.empty()) {
                     if (rank == 0)
@@ -482,12 +482,16 @@ int main(int argc, char **argv)
                 }
 
                 int partner = my_partner[rank];
-                if (partner == MPI_PROC_NULL) {
+
+                // ---- CLEAN FIX #1: split communicator so only paired ranks participate ----
+                const int active = (partner != MPI_PROC_NULL);
+                MPI_Comm pp_comm = MPI_COMM_NULL;
+                MPI_Comm_split(MPI_COMM_WORLD, active ? 0 : MPI_UNDEFINED, rank, &pp_comm);
+
+                if (!active) {
+                    // Not in any pair for this region: do NOT touch barriers inside this region
                     continue;
                 }
-
-                // printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
-                //            region_label.c_str(), pairs.size(), partner_rank);
 
                 if (rank == 0)
                 {
@@ -498,6 +502,7 @@ int main(int argc, char **argv)
                                p.src, all_hostnames[p.src],
                                p.dst, all_hostnames[p.dst]);
                     }
+                    fflush(stdout);
 
 #if defined(USE_CALIPER)
                     // Use the first pair as representative for Caliper attributes
@@ -513,10 +518,13 @@ int main(int argc, char **argv)
                 double total_time = 0.0;
                 int warmup = 1;
 
-                // OSU-style directional tags for this pair:
-                // lower rank receives TAG_A and sends TAG_B; higher rank receives TAG_B and sends TAG_A
-                const int TAG_A = 10;
-                const int TAG_B = 100;
+                // ---- CLEAN FIX #2: per-region tags to avoid cross-region message matching ----
+                // Keep tags safely below typical MPI_TAG_UB by bounding with modulo.
+                const int base_tag = 1000 + ((partner_rank % 2000) * 10);
+                const int TAG_A = base_tag + 0;
+                const int TAG_B = base_tag + 1;
+
+                // OSU-style directional tags for CPU path
                 const int my_recv_tag = (rank < partner) ? TAG_A : TAG_B;
                 const int my_send_tag = (rank < partner) ? TAG_B : TAG_A;
 
@@ -584,6 +592,9 @@ int main(int argc, char **argv)
                 std::vector<MPI_Request> recv_request(WINDOW_SIZE);
 #endif
 
+                // Sync ONLY participating ranks
+                MPI_Barrier(pp_comm);
+
                 // ---------- warmup ----------
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region);
@@ -592,27 +603,27 @@ int main(int argc, char **argv)
                 {
 #if defined(USE_HIP)
                     if (rank < partner) {
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
                     } else {
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
                     }
 #elif defined(USE_CUDA)
                     if (rank < partner) {
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Send(h_send, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
                         cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
                     } else {
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
                         cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Send(h_send, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
                     }
 #else
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
@@ -623,17 +634,10 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
-                    // printf("rank: %d before MPI_Barrier before inside warmup %d\n", rank, i);
-                    // MPI_Barrier(MPI_COMM_WORLD);
-                    printf("rank: %d after MPI_Barrier before waitall inside warmup %d\n", rank, i);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    printf("rank: %d After Waitall warmup %d\n", rank, i);
 #endif
                 }
-                // printf("rank: %d before MPI_Barrier outside warmup\n", rank);
-                // MPI_Barrier(MPI_COMM_WORLD);
-                // printf("rank: %d after MPI_Barrier outside warmup\n", rank);
 
 #if defined(USE_CALIPER)
                 CALI_MARK_END(warmup_region);
@@ -647,7 +651,7 @@ int main(int argc, char **argv)
 
                 bool i_am_timing_rank = (rank < partner);
 
-                MPI_Barrier(MPI_COMM_WORLD);
+                MPI_Barrier(pp_comm);
 
                 for (int i = 0; i < PING_PONG_LIMIT; i++)
                 {
@@ -658,27 +662,27 @@ int main(int argc, char **argv)
 
 #if defined(USE_HIP)
                     if (rank < partner) {
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
                     } else {
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
                     }
 #elif defined(USE_CUDA)
                     if (rank < partner) {
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Send(h_send, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
                         cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
                     } else {
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
                         cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Send(h_send, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
                     }
 #else
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
@@ -689,12 +693,8 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
-                    // printf("rank: %d before MPI_Barrier inside iteration %d\n", rank, i);
-                    // MPI_Barrier(MPI_COMM_WORLD);
-                    printf("rank: %d after MPI_barrier before waitall inside iteration %d\n", rank, i);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    printf("rank: %d After MPI_Waitall %d\n", rank, i);
 #endif
 
                     if (i_am_timing_rank) {
@@ -706,9 +706,8 @@ int main(int argc, char **argv)
                         ++iters;
                     }
                 }
-                // printf("rank: %d before MPI_Barrier outside iteration loop\n", rank);
-                // MPI_Barrier(MPI_COMM_WORLD);
-                // printf("rank: %d after MPI_Barrier outside iteration loop\n", rank);
+
+                MPI_Barrier(pp_comm);
 
                 if (i_am_timing_rank)
                 {
@@ -724,6 +723,7 @@ int main(int argc, char **argv)
                     printf("PINGPONG %s pair (%d,%d): avg=%g s, min=%g s, max=%g s\n",
                            region_label.c_str(), rank, partner,
                            avg_rtt, min_rtt, max_rtt);
+                    fflush(stdout);
                 }
 
 #if defined(USE_CALIPER)
@@ -743,8 +743,12 @@ int main(int argc, char **argv)
                 free(send_flat);
                 free(recv_flat);
 #endif
+
+                MPI_Comm_free(&pp_comm);
+
             } // end for (partner_rank : partners)
-            printf("Done with Pingpong");
+
+            if (rank == 0) printf("Done with Pingpong\n");
         }     // end if (PingPong || All)
 
         MPI_Barrier(MPI_COMM_WORLD);

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -908,6 +908,7 @@ int main(int argc, char **argv)
                 free(aa_send);
                 free(aa_recv);
 #endif
+                sleep(1);
             }
         }
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -196,7 +196,7 @@ int main(int argc, char **argv)
 #endif
 
     int PING_PONG_LIMIT = 10;
-    const int WINDOW_SIZE = 1; // OSU-style window exchange; no SINGLE/MULTIPLE modes
+    const int WINDOW_SIZE = 64; // OSU-style window exchange; no SINGLE/MULTIPLE modes
     int msg_size = 1;
     int n_nodes = 1;
     int sys_cores_per_socket = 1;
@@ -518,8 +518,6 @@ int main(int argc, char **argv)
                 double total_time = 0.0;
                 int warmup = 1;
 
-                // ---- CLEAN FIX #2: per-region tags to avoid cross-region message matching ----
-                // Keep tags safely below typical MPI_TAG_UB by bounding with modulo.
                 const int base_tag = 1000 + ((partner_rank % 2000) * 10);
                 const int TAG_A = base_tag + 0;
                 const int TAG_B = base_tag + 1;

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -618,17 +618,17 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
-                    printf("before MPI_Barrier before inside warmup");
+                    printf("before MPI_Barrier before inside warmup %d\n", i);
                     MPI_Barrier(MPI_COMM_WORLD);
-                    printf("after MPI_Barrier before waitall inside warmup");
+                    printf("after MPI_Barrier before waitall inside warmup %d\n", i);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    printf("After Waitall warmup");
+                    printf("After Waitall warmup %d\n", i);
 #endif
                 }
-                printf("before MPI_Barrier outside warmup");
+                printf("before MPI_Barrier outside warmup\n");
                 MPI_Barrier(MPI_COMM_WORLD);
-                printf("after MPI_Barrier outside warmup");
+                printf("after MPI_Barrier outside warmup\n");
 
 #if defined(USE_CALIPER)
                 CALI_MARK_END(warmup_region);
@@ -684,12 +684,12 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
-                    printf("before MPI_Barrier inside iteration");
+                    printf("before MPI_Barrier inside iteration %d\n", i);
                     MPI_Barrier(MPI_COMM_WORLD);
-                    printf("after MPI_barrier before waitall inside iteration");
+                    printf("after MPI_barrier before waitall inside iteration %d\n", i);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    printf("After MPI_Waitall");
+                    printf("After MPI_Waitall %d\n", i);
 #endif
 
                     if (i_am_timing_rank) {
@@ -701,9 +701,9 @@ int main(int argc, char **argv)
                         ++iters;
                     }
                 }
-                printf("before MPI_Barrier outside iteration loop");
+                printf("before MPI_Barrier outside iteration loop\n");
                 MPI_Barrier(MPI_COMM_WORLD);
-                printf("after MPI_Barrier outside iteration loop");
+                printf("after MPI_Barrier outside iteration loop\n");
 
                 if (i_am_timing_rank)
                 {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -701,6 +701,7 @@ int main(int argc, char **argv)
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
 #endif
 
+                    // calculation for round-trip time
                     if (i_am_timing_rank) {
                         end = MPI_Wtime();
                         double rtt = end - start;

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -171,6 +171,7 @@ build_pingpong_pairs(const std::string& region_label,
     return pairs;
 }
 
+
 int main(int argc, char **argv)
 {
     int rank, size;
@@ -195,7 +196,6 @@ int main(int argc, char **argv)
 #endif
 
     int PING_PONG_LIMIT = 10;
-    const int WINDOW_SIZE = 1;
     int msg_size = 1;
     int n_nodes = 1;
     int sys_cores_per_socket = 1;
@@ -217,6 +217,7 @@ int main(int argc, char **argv)
         "[-O pingpong|alltoall|reduce|allreduce|all]\n"
         "Default: -O pingpong\n";
 
+    // add 'O:' to parse the selector
     while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:O:")) != -1)
     {
         switch (opt)
@@ -229,7 +230,7 @@ int main(int argc, char **argv)
                 PING_PONG_LIMIT = atoi(optarg);
                 break;
             case 'p':
-                // kept for compatibility
+                // kept for compatibility; you can parse partners here if desired
                 break;
             case 'm':
                 msg_size = atoi(optarg);
@@ -511,7 +512,6 @@ int main(int argc, char **argv)
 
                 // ---------- buffer allocation ----------
 #if defined(USE_HIP)
-                // (kept exactly like your older HIP path: device pointers passed to MPI)
                 char *send_buf;
                 char *recv_buf;
 
@@ -537,7 +537,6 @@ int main(int argc, char **argv)
                 assert(cuerr2 == hipSuccess);
 
 #elif defined(USE_CUDA)
-                // (kept exactly like your older CUDA path: stage through pinned host)
                 int dev_count = 0;
                 cuda_check(cudaGetDeviceCount(&dev_count));
                 cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
@@ -555,33 +554,28 @@ int main(int argc, char **argv)
                 memset(h_recv, 0, message);
 
                 cuda_check(cudaMemcpy(d_send, h_send, message, cudaMemcpyHostToDevice));
-                cuda_check(cudaMemset(d_recv, 0, message);
+                cuda_check(cudaMemset(d_recv, 0, message));
 
 #else
-                // MPI-only: allocate + fill ONCE (no per-iteration refill)
-                char* send_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
-                char* recv_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
+                const int iters_total = PING_PONG_LIMIT;
 
-                std::vector<char*> send_rows(WINDOW_SIZE);
-                std::vector<char*> recv_rows(WINDOW_SIZE);
+                char* send_flat = (char*)malloc((size_t)iters_total * (size_t)message);
+                char* recv_flat = (char*)malloc((size_t)iters_total * (size_t)message);
 
-                for (int j = 0; j < WINDOW_SIZE; ++j) {
-                    send_rows[j] = send_flat + (size_t)j * (size_t)message;
-                    recv_rows[j] = recv_flat + (size_t)j * (size_t)message;
-
-                    fill_with_random_pattern(send_rows[j], (size_t)message); // ✅ fill once
-                    memset(recv_rows[j], 0, (size_t)message);
+                std::vector<char*> send_rows(iters_total);
+                std::vector<char*> recv_rows(iters_total);
+                for (int it = 0; it < iters_total; ++it) {
+                    send_rows[it] = send_flat + (size_t)it * (size_t)message;
+                    recv_rows[it] = recv_flat + (size_t)it * (size_t)message;
+                    fill_with_random_pattern(send_rows[it], (size_t)message);
+                    memset(recv_rows[it], 0, (size_t)message);
                 }
-
-                std::vector<MPI_Request> sreqs(WINDOW_SIZE);
-                std::vector<MPI_Request> rreqs(WINDOW_SIZE);
 #endif
 
                 // ---------- warmup ----------
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region);
 #endif
-                const int tag_base = 1000;
                 for (int i = 0; i < warmup; i++)
                 {
 #if defined(USE_HIP)
@@ -609,19 +603,19 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
-                    // ✅ NO refill here
-                    for (int j = 0; j < WINDOW_SIZE; ++j) {
-                        MPI_Irecv(recv_rows[j], message, MPI_CHAR, partner,
-                                  tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
-                    }
+                    int it = i % iters_total;
+                    char* srow = send_rows[it];
+                    char* rrow = recv_rows[it];
 
-                    for (int j = 0; j < WINDOW_SIZE; ++j) {
-                        MPI_Isend(send_rows[j], message, MPI_CHAR, partner,
-                                  tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                    if (rank < partner) {
+                        MPI_Send(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                MPI_STATUS_IGNORE);
+                    } else {
+                        MPI_Recv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                MPI_STATUS_IGNORE);
+                        MPI_Send(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
-
-                    MPI_Waitall(WINDOW_SIZE, rreqs.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall(WINDOW_SIZE, sreqs.data(), MPI_STATUSES_IGNORE);
 #endif
                 }
 #if defined(USE_CALIPER)
@@ -629,19 +623,21 @@ int main(int argc, char **argv)
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
 
-                // ---------- timed ping-pong ----------
+                // ---------- timed ping-pong (multiple pairs at once) ----------
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
+                MPI_Request rreq, sreq;
 
                 // One rank per pair records timings (the "lower" rank)
                 bool i_am_timing_rank = (rank < partner);
 
-                MPI_Barrier(MPI_COMM_WORLD);
-
                 for (int i = 0; i < PING_PONG_LIMIT; i++)
                 {
                     double start = 0.0, end = 0.0;
+
+                    if (i_am_timing_rank)
+                        start = MPI_Wtime();
 
 #if defined(USE_HIP)
                     if (rank < partner) {
@@ -668,30 +664,22 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
-                    // ✅ NO refill here
-                    if (i_am_timing_rank){
-                        start = MPI_Wtime();
-                    }
+                    char* srow = send_rows[i];
+                    char* rrow = recv_rows[i];
 
-                    for (int j = 0; j < WINDOW_SIZE; ++j) {
-                        MPI_Irecv(recv_rows[j], message, MPI_CHAR, partner,
-                                  tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
+                    if (rank < partner) {
+                        MPI_Isend(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
+                        MPI_Irecv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &rreq);
+                    } else {
+                        MPI_Irecv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &rreq);
+                        MPI_Isend(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
                     }
-
-                    for (int j = 0; j < WINDOW_SIZE; ++j) {
-                        MPI_Isend(send_rows[j], message, MPI_CHAR, partner,
-                                  tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
-                    }
-
-                    MPI_Waitall(WINDOW_SIZE, rreqs.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall(WINDOW_SIZE, sreqs.data(), MPI_STATUSES_IGNORE);
-
-                    if (i_am_timing_rank){
-                        end = MPI_Wtime();
-                    }
+                    MPI_Wait(&rreq, MPI_STATUS_IGNORE);
+                    MPI_Wait(&sreq, MPI_STATUS_IGNORE);
 #endif
 
                     if (i_am_timing_rank) {
+                        end = MPI_Wtime();
                         double rtt = end - start;
                         total_time += rtt;
                         if (rtt < min_rtt) min_rtt = rtt;
@@ -711,6 +699,7 @@ int main(int argc, char **argv)
                     cali_set_double(pp_min_time_sec_attr, min_rtt);
 #endif
 
+                    // Optional: print per-pair stats
                     printf("PINGPONG %s pair (%d,%d): avg=%g s, min=%g s, max=%g s\n",
                            region_label.c_str(), rank, partner,
                            avg_rtt, min_rtt, max_rtt);

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -614,6 +614,7 @@ int main(int argc, char **argv)
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
+                MPI_Request rreq, sreq;
 
                 // One rank per pair records timings (the "lower" rank)
                 bool i_am_timing_rank = (rank < partner);
@@ -651,14 +652,16 @@ int main(int argc, char **argv)
                     }
 #else
                     if (rank < partner) {
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
+                        MPI_ISend(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
+                        MPI_IRecv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 &rreq);
                     } else {
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_IRecv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 &rreq);
+                        MPI_ISend(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
                     }
+                    MPI_Wait( &rreq, MPI_STATUS_IGNORE);
+                    MPI_Wait( &sreq, MPI_STATUS_IGNORE);
 #endif
 
                     if (i_am_timing_rank) {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -115,15 +115,35 @@ build_pingpong_pairs(const std::string& region_label,
     };
 
     if (region_label == "Same Node Same Socket") {
-        add_pair(0, 1);
+        int rps = sys_cores_per_socket;
+        if (rps < 2) return pairs;
+
+        int s0 = 0;
+        int s1 = rps / 8;
+        int s2 = rps / 4;
+        int s3 = (rps / 2) - 2;
+
+        add_pair(s0, s0 + 1);
+        add_pair(s1, s1 + 1);
+        add_pair(s2, s2 + 1);
+        add_pair(s3, s3 + 1);
+
         return pairs;
     }
 
     if (region_label == "Same Node Different Socket") {
         int rps = sys_cores_per_socket;
-        int half = rps / 2;
+        int delta = rps;
 
-        add_pair(0, half);
+        int s0 = 0;
+        int s1 = delta / 8;
+        int s2 = delta / 4;
+        int s3 = (delta / 2) - 1;
+
+        add_pair(s0, rps / 2);
+        add_pair(s1, (rps / 2) + 1);
+        add_pair(s2, (rps / 2) + 2);
+        add_pair(s3, rps - 1);
 
         return pairs;
     }
@@ -131,14 +151,13 @@ build_pingpong_pairs(const std::string& region_label,
     int nodes_in_comm = 0;
     {
         std::stringstream ss(region_label);
-        ss >> nodes_in_comm; // stops at "nodes"
+        ss >> nodes_in_comm;
     }
 
     if (nodes_in_comm >= 2) {
         int rpn   = sys_cores_per_node;
         int delta = (nodes_in_comm / 2) * rpn;
 
-        // We spread srcs across the first node:
         int srcs[4] = { 0, rpn / 4, rpn / 2, rpn - 1 };
 
         for (int s : srcs)
@@ -194,11 +213,11 @@ int main(int argc, char **argv)
     int opt;
     const char *usage =
         "Usage: %s [-h] [-i n-iterations] [-p rank1,rank2] [-m msg_sz] "
-        "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] [-b metadata] "
+        "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] [-b metadata] [-k pingpong_num_pairs]"
         "[-O pingpong|alltoall|reduce|allreduce|all]\n"
         "Default: -O pingpong\n";
 
-    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:O:")) != -1)
+    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:k:O:")) != -1)
     {
         switch (opt)
         {
@@ -226,6 +245,9 @@ int main(int argc, char **argv)
                 break;
             case 'b':
                 metadata = optarg;
+                break;
+            case 'k':
+                pingpong_num_pairs = optarg;
                 break;
             case 'O':
             {
@@ -257,6 +279,7 @@ int main(int argc, char **argv)
         printf("Cores per node: %d\n", sys_cores_per_node);
         printf("Nodes: %d\n", n_nodes);
         printf("World size: %d\n", size);
+        printf("Pingpong num pairs: %d\n", pingpong_num_pairs);
         printf("Mode (-O): %s\n",
                op == OpKind::PingPong ? "pingpong" :
                op == OpKind::Alltoall ? "alltoall" :
@@ -675,7 +698,6 @@ int main(int argc, char **argv)
                     }
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    //MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
 #endif
 
                     if (i_am_timing_rank) {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -497,98 +497,36 @@ int main(int argc, char **argv)
 #endif
 
         // ===================== PINGPONG =====================
+        // ===================== PINGPONG =====================
         if (op == OpKind::PingPong || op == OpKind::All)
         {
-            for (int partner_rank : partners)
-            {
-                std::string region_label = region_names[partner_rank];
+            const int ITERS = PING_PONG_LIMIT;
+            const int W     = WINDOW_SIZE;
+            const size_t bytes_per_row = (size_t)message;
+            const size_t total_rows    = (size_t)ITERS * (size_t)W;
 
-                // Build up to 4 pairs for this region
-                std::vector<RankPair> pairs =
-                    build_pingpong_pairs(region_label,
-                                         size,
-                                         sys_cores_per_socket,
-                                         sys_cores_per_node, pingpong_num_pairs);
+            const size_t send2d_bytes      = total_rows * bytes_per_row;
+            const size_t recv_window_bytes = (size_t)W * bytes_per_row;
 
-                if (pairs.empty()) {
-                    if (rank == 0)
-                        printf("Skipping region %s: no valid pingpong pairs\n",
-                               region_label.c_str());
-                    continue;
-                }
+            char* host_send_2d  = (char*)host_alloc(send2d_bytes);
+            char* host_recv_win = (char*)host_alloc(recv_window_bytes);
+            if (!host_send_2d || !host_recv_win) {
+                if (rank == 0) fprintf(stderr, "host_alloc failed\n");
+                MPI_Abort(MPI_COMM_WORLD, 1);
+            }
 
-                // Map each rank to its partner (or MPI_PROC_NULL if not in any pair)
-                std::vector<int> my_partner(size, MPI_PROC_NULL);
-                for (auto &p : pairs) {
-                    my_partner[p.src] = p.dst;
-                    my_partner[p.dst] = p.src;
-                }
+            for (size_t r = 0; r < total_rows; ++r) {
+                fill_with_random_pattern(row_ptr(host_send_2d, bytes_per_row, r), bytes_per_row);
+            }
+            memset(host_recv_win, 0, recv_window_bytes);
 
-                int partner = my_partner[rank];
-                if (partner == MPI_PROC_NULL) {
-                    // This rank does not participate in this region's pingpong
-                    continue;
-                }
+            std::vector<MPI_Request> sreqs(W, MPI_REQUEST_NULL);
+            std::vector<MPI_Request> rreqs(W, MPI_REQUEST_NULL);
 
-                if (rank == 0)
-                {
-                    printf("\n--- Testing %s (PINGPONG) with %zu pairs ---\n",
-                           region_label.c_str(), pairs.size());
-                    for (auto &p : pairs) {
-                        printf("  pair %d (%s) <-> %d (%s)\n",
-                               p.src, all_hostnames[p.src],
-                               p.dst, all_hostnames[p.dst]);
-                    }
-
-#if defined(USE_CALIPER)
-                    // Use the first pair as representative for Caliper attributes
-                    cali_set_int(src_rank_attr, pairs[0].src);
-                    cali_set_int(dest_rank_attr, pairs[0].dst);
-                    cali_set_int(src_node_attr,
-                                 extract_node_number(all_hostnames[pairs[0].src]));
-                    cali_set_int(dest_node_attr,
-                                 extract_node_number(all_hostnames[pairs[0].dst]));
-#endif
-                }
-
-                // ------------------------------------------------------------
-                // Canonical pre-filled 2D payload (OUTSIDE MPI/CUDA/HIP branches)
-                // rows = PING_PONG_LIMIT * WINDOW_SIZE
-                // row(i,j) holds unique data
-                // ------------------------------------------------------------
-                const int ITERS = PING_PONG_LIMIT;
-                const int W     = WINDOW_SIZE;
-                const size_t bytes_per_row = (size_t)message;
-                const size_t total_rows    = (size_t)ITERS * (size_t)W;
-
-                const size_t send2d_bytes      = total_rows * bytes_per_row;
-                const size_t recv_window_bytes = (size_t)W * bytes_per_row;
-
-                char* host_send_2d  = (char*)host_alloc(send2d_bytes);
-                char* host_recv_win = (char*)host_alloc(recv_window_bytes);
-                if (!host_send_2d || !host_recv_win) {
-                    if (rank == 0) fprintf(stderr, "host_alloc failed\n");
-                    MPI_Abort(MPI_COMM_WORLD, 1);
-                }
-
-                // Fill ONCE: each (iter,window_slot) has different content
-                for (size_t r = 0; r < total_rows; ++r) {
-                    fill_with_random_pattern(row_ptr(host_send_2d, bytes_per_row, r), bytes_per_row);
-                }
-                memset(host_recv_win, 0, recv_window_bytes);
-
-                // Requests (CPU-side handle arrays) always exist
-                std::vector<MPI_Request> sreqs(W, MPI_REQUEST_NULL);
-                std::vector<MPI_Request> rreqs(W, MPI_REQUEST_NULL);
-
-                // ------------------------------------------------------------
-                // Backend buffers (only for CUDA/HIP; MPI-only uses host directly)
-                // We still DO NOT generate/refill inside timed loop—just index.
-                // ------------------------------------------------------------
 #if defined(USE_HIP)
-                // Optionally keep a full device copy of the 2D send payload:
-                char* d_send_2d = nullptr;
-                char* d_recv_win = nullptr;
+            char* d_send_2d = nullptr;
+            char* d_recv_win = nullptr;
+            {
                 hipError_t e1 = hipMalloc((void**)&d_send_2d, send2d_bytes);
                 hipError_t e2 = hipMalloc((void**)&d_recv_win, recv_window_bytes);
                 if (e1 != hipSuccess || e2 != hipSuccess) {
@@ -603,37 +541,80 @@ int main(int argc, char **argv)
                             hipGetErrorString(e3), hipGetErrorString(e4));
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
-
-                // If NOT GPU-aware MPI, we will stage through host buffers (already pinned via host_alloc)
-                // using host_send_2d row pointers directly.
+            }
 #elif defined(USE_CUDA)
-                int dev_count = 0;
-                cuda_check(cudaGetDeviceCount(&dev_count));
-                cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
+            int dev_count = 0;
+            cuda_check(cudaGetDeviceCount(&dev_count));
+            cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
 
-                char* d_send_2d = nullptr;
-                char* d_recv_win = nullptr;
-                cuda_check(cudaMalloc((void**)&d_send_2d, send2d_bytes));
-                cuda_check(cudaMalloc((void**)&d_recv_win, recv_window_bytes));
-                cuda_check(cudaMemcpy(d_send_2d, host_send_2d, send2d_bytes, cudaMemcpyHostToDevice));
-                cuda_check(cudaMemset(d_recv_win, 0, recv_window_bytes));
+            char* d_send_2d = nullptr;
+            char* d_recv_win = nullptr;
+            cuda_check(cudaMalloc((void**)&d_send_2d, send2d_bytes));
+            cuda_check(cudaMalloc((void**)&d_recv_win, recv_window_bytes));
+            cuda_check(cudaMemcpy(d_send_2d, host_send_2d, send2d_bytes, cudaMemcpyHostToDevice));
+            cuda_check(cudaMemset(d_recv_win, 0, recv_window_bytes));
 #endif
+
+            for (int partner_rank : partners)
+            {
+                std::string region_label = region_names[partner_rank];
+
+                std::vector<RankPair> pairs =
+                    build_pingpong_pairs(region_label,
+                                        size,
+                                        sys_cores_per_socket,
+                                        sys_cores_per_node, pingpong_num_pairs);
+
+                if (pairs.empty()) {
+                    if (rank == 0)
+                        printf("Skipping region %s: no valid pingpong pairs\n",
+                            region_label.c_str());
+                    continue;
+                }
+
+                std::vector<int> my_partner(size, MPI_PROC_NULL);
+                for (auto &p : pairs) {
+                    my_partner[p.src] = p.dst;
+                    my_partner[p.dst] = p.src;
+                }
+
+                int partner = my_partner[rank];
+                if (partner == MPI_PROC_NULL)
+                    continue;
+
+                if (rank == 0)
+                {
+                    printf("\n--- Testing %s (PINGPONG) with %zu pairs ---\n",
+                        region_label.c_str(), pairs.size());
+                    for (auto &p : pairs) {
+                        printf("  pair %d (%s) <-> %d (%s)\n",
+                            p.src, all_hostnames[p.src],
+                            p.dst, all_hostnames[p.dst]);
+                    }
+
+#if defined(USE_CALIPER)
+                    cali_set_int(src_rank_attr, pairs[0].src);
+                    cali_set_int(dest_rank_attr, pairs[0].dst);
+                    cali_set_int(src_node_attr,
+                                extract_node_number(all_hostnames[pairs[0].src]));
+                    cali_set_int(dest_node_attr,
+                                extract_node_number(all_hostnames[pairs[0].dst]));
+#endif
+                }
 
                 double total_time = 0.0;
                 const int warmup = 1;
                 const int tag_base = 1000;
 
-                // ---------- warmup ----------
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region);
 #endif
                 for (int w = 0; w < warmup; ++w)
                 {
-                    const int warm_iter = 0; // warmup always uses row set for iter 0
+                    const int warm_iter = 0;
 
 #if defined(USE_HIP) || defined(USE_CUDA)
 #if ASSUME_GPU_AWARE_MPI
-                    // GPU-aware: send/recv directly using device pointers into the device 2D buffer
                     if (rank < partner) {
                         for (int j = 0; j < W; ++j) {
                             size_t r = row_index(warm_iter, j, W);
@@ -651,8 +632,7 @@ int main(int argc, char **argv)
                             MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
                         }
                     }
-#else
-                    // Not GPU-aware: use canonical host 2D rows directly for MPI; optionally move recv into device window
+        #else
                     if (rank < partner) {
                         for (int j = 0; j < W; ++j) {
                             size_t r = row_index(warm_iter, j, W);
@@ -670,22 +650,14 @@ int main(int argc, char **argv)
                             MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
                         }
                     }
-
-                    // Mirror recv window into device (optional, preserves your old “device recv” behavior)
-#if defined(USE_HIP)
-                    hipMemcpy(d_recv_win, host_recv_win, recv_window_bytes, hipMemcpyHostToDevice);
-#elif defined(USE_CUDA)
-                    cuda_check(cudaMemcpy(d_recv_win, host_recv_win, recv_window_bytes, cudaMemcpyHostToDevice));
 #endif
-#endif // ASSUME_GPU_AWARE_MPI
 #else
-                    // Plain MPI warmup: post WINDOW_SIZE irecvs/isends using iter 0 rows
                     for (int j = 0; j < W; ++j) {
                         size_t r = row_index(warm_iter, j, W);
                         MPI_Irecv(host_recv_win + (size_t)j * bytes_per_row, message, MPI_CHAR,
-                                  partner, tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
+                                partner, tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
                         MPI_Isend((void*)row_ptr(host_send_2d, bytes_per_row, r), message, MPI_CHAR,
-                                  partner, tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                                partner, tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
                     }
                     MPI_Waitall(W, rreqs.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(W, sreqs.data(), MPI_STATUSES_IGNORE);
@@ -696,14 +668,11 @@ int main(int argc, char **argv)
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
 
-                // ---------- timed ping-pong (NO refill; just index 2D rows) ----------
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
 
-                // One rank per pair records timings (the "lower" rank)
                 bool i_am_timing_rank = (rank < partner);
-
                 MPI_Barrier(MPI_COMM_WORLD);
 
                 for (int i = 0; i < ITERS; i++)
@@ -711,9 +680,8 @@ int main(int argc, char **argv)
                     double start = 0.0, end = 0.0;
 
 #if defined(USE_HIP) || defined(USE_CUDA)
+                    if (i_am_timing_rank) start = MPI_Wtime();
 #if ASSUME_GPU_AWARE_MPI
-                    if (i_am_timing_rank) start = MPI_Wtime();
-
                     if (rank < partner) {
                         for (int j = 0; j < W; ++j) {
                             size_t r = row_index(i, j, W);
@@ -731,12 +699,7 @@ int main(int argc, char **argv)
                             MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
                         }
                     }
-
-                    if (i_am_timing_rank) end = MPI_Wtime();
 #else
-                    // Not GPU-aware: MPI uses canonical host 2D rows directly.
-                    if (i_am_timing_rank) start = MPI_Wtime();
-
                     if (rank < partner) {
                         for (int j = 0; j < W; ++j) {
                             size_t r = row_index(i, j, W);
@@ -754,29 +717,18 @@ int main(int argc, char **argv)
                             MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
                         }
                     }
-
-                    // Mirror recv window into device (optional)
-#if defined(USE_HIP)
-                    hipMemcpy(d_recv_win, host_recv_win, recv_window_bytes, hipMemcpyHostToDevice);
-#elif defined(USE_CUDA)
-                    cuda_check(cudaMemcpy(d_recv_win, host_recv_win, recv_window_bytes, cudaMemcpyHostToDevice));
 #endif
-
                     if (i_am_timing_rank) end = MPI_Wtime();
-#endif // ASSUME_GPU_AWARE_MPI
 #else
                     if (i_am_timing_rank) start = MPI_Wtime();
 
                     for (int j = 0; j < W; ++j) {
                         size_t r = row_index(i, j, W);
-
                         MPI_Irecv(host_recv_win + (size_t)j * bytes_per_row, message, MPI_CHAR, partner,
-                                  tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
-
+                                tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
                         MPI_Isend((void*)row_ptr(host_send_2d, bytes_per_row, r), message, MPI_CHAR, partner,
-                                  tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                                tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
                     }
-
                     MPI_Waitall(W, rreqs.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(W, sreqs.data(), MPI_STATUSES_IGNORE);
 
@@ -802,29 +754,26 @@ int main(int argc, char **argv)
                     cali_set_double(pp_max_time_sec_attr, max_rtt);
                     cali_set_double(pp_min_time_sec_attr, min_rtt);
 #endif
-
                     printf("PINGPONG %s pair (%d,%d): avg=%g s, min=%g s, max=%g s\n",
-                           region_label.c_str(), rank, partner,
-                           avg_rtt, min_rtt, max_rtt);
+                        region_label.c_str(), rank, partner,
+                        avg_rtt, min_rtt, max_rtt);
                 }
 
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
 #endif
-
-                // ---------- cleanup ----------
+            }
 #if defined(USE_HIP)
-                hipFree(d_send_2d);
-                hipFree(d_recv_win);
+            hipFree(d_send_2d);
+            hipFree(d_recv_win);
 #elif defined(USE_CUDA)
-                cuda_check(cudaFree(d_send_2d));
-                cuda_check(cudaFree(d_recv_win));
+            cuda_check(cudaFree(d_send_2d));
+            cuda_check(cudaFree(d_recv_win));
 #endif
-                host_free(host_send_2d);
-                host_free(host_recv_win);
+            host_free(host_send_2d);
+            host_free(host_recv_win);
+        }
 
-            } // end for (partner_rank : partners)
-        }     // end if (PingPong || All)
 
         MPI_Barrier(MPI_COMM_WORLD);
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -568,6 +568,7 @@ int main(int argc, char **argv)
 
                 std::vector<MPI_Request> send_request(WINDOW_SIZE);
                 std::vector<MPI_Request> recv_request(WINDOW_SIZE);
+                std::vector<MPI_Request> reqs(2 * WINDOW_SIZE);
 #endif
 
                 // Sync ONLY participating ranks
@@ -606,14 +607,15 @@ int main(int argc, char **argv)
 #else
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
                         MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
-                                  MPI_COMM_WORLD, &recv_request[j]);
+                                  MPI_COMM_WORLD, &reqs[j]);
                     }
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
-                                  MPI_COMM_WORLD, &send_request[j]);
+                                  MPI_COMM_WORLD, &reqs[WINDOW_SIZE + j]);
                     }
-                    MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    //MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    //MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
 #endif
                 }
 
@@ -665,14 +667,15 @@ int main(int argc, char **argv)
 #else
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
                         MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
-                                  MPI_COMM_WORLD, &recv_request[j]);
+                                  MPI_COMM_WORLD, &reqs[j]);
                     }
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
-                                  MPI_COMM_WORLD, &send_request[j]);
+                                  MPI_COMM_WORLD, &reqs[WINDOW_SIZE + j]);
                     }
-                    MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    //MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    //MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
 #endif
 
                     if (i_am_timing_rank) {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -247,7 +247,7 @@ int main(int argc, char **argv)
                 metadata = optarg;
                 break;
             case 'k':
-                pingpong_num_pairs = optarg;
+                pingpong_num_pairs = atoi(optarg);
                 break;
             case 'O':
             {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -415,7 +415,7 @@ int main(int argc, char **argv)
         region_names[1] = "Same Node Same Socket";
     }
 
-    for (int message = msg_size; message <= pow(msg_size, 6); message *= 8)
+    for (int message = msg_size; message <= pow(msg_size, 1); message *= 8)
     {
 #if defined(USE_CALIPER)
         std::string profile = "spot(output=" + std::to_string(message) + "_" +

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -115,35 +115,15 @@ build_pingpong_pairs(const std::string& region_label,
     };
 
     if (region_label == "Same Node Same Socket") {
-        int rps = sys_cores_per_socket;
-        if (rps < 2) return pairs;
-
-        int s0 = 0;
-        int s1 = rps / 8;
-        int s2 = rps / 4;
-        int s3 = (rps / 2) - 2;
-
-        add_pair(s0, s0 + 1);
-        add_pair(s1, s1 + 1);
-        add_pair(s2, s2 + 1);
-        add_pair(s3, s3 + 1);
-
+        add_pair(0, 1);
         return pairs;
     }
 
     if (region_label == "Same Node Different Socket") {
         int rps = sys_cores_per_socket;
-        int delta = rps;
+        int half = rps / 2;
 
-        int s0 = 0;
-        int s1 = delta / 8;
-        int s2 = delta / 4;
-        int s3 = (delta / 2) - 1;
-
-        add_pair(s0, rps / 2);
-        add_pair(s1, (rps / 2) + 1);
-        add_pair(s2, (rps / 2) + 2);
-        add_pair(s3, rps - 1);
+        add_pair(0, half);
 
         return pairs;
     }

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -45,7 +45,7 @@ inline void cuda_check(cudaError_t e) {
 #endif
 
 // ---- Operation selector (default: PingPong) ----
-enum class OpKind { All, PingPong, Alltoall, Reduce, Allreduce };
+enum class OpKind { All, PingPong, Alltoall, Reduce, Allreduce, Bandwidth };
 
 const char *get_hostname_for_rank(int rank, char all_hostnames[][1024], int size)
 {
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
     const char *usage =
         "Usage: %s [-h] [-i n-iterations] [-p rank1,rank2] [-m msg_sz] "
         "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] [-b metadata] [-k pingpong_num_pairs]"
-        "[-O pingpong|alltoall|reduce|allreduce|all]\n"
+        "[-O pingpong|alltoall|reduce|allreduce|bandwidth|all]\n"
         "Default: -O pingpong\n";
 
     while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:k:O:")) != -1)
@@ -258,10 +258,11 @@ int main(int argc, char **argv)
                 else if (s == "alltoall") op = OpKind::Alltoall;
                 else if (s == "reduce")   op = OpKind::Reduce;
                 else if (s == "allreduce")op = OpKind::Allreduce;
+                else if (s == "bandwidth")op = OpKind::Bandwidth;
                 else if (s == "all")      op = OpKind::All;
                 else {
                     if (rank == 0)
-                        fprintf(stderr, "Unknown -O value '%s'. Expected pingpong|alltoall|reduce|allreduce|all\n", s.c_str());
+                        fprintf(stderr, "Unknown -O value '%s'. Expected pingpong|alltoall|reduce|allreduce|bandwidth|all\n", s.c_str());
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
                 break;
@@ -286,7 +287,8 @@ int main(int argc, char **argv)
                op == OpKind::PingPong ? "pingpong" :
                op == OpKind::Alltoall ? "alltoall" :
                op == OpKind::Reduce   ? "reduce" :
-               op == OpKind::Allreduce? "allreduce" : "all");
+               op == OpKind::Allreduce? "allreduce" : 
+               op == OpKind::Bandwidth? "bandwidth" : "all");
 
 #if defined(USE_CALIPER)
         std::stringstream rankmap;
@@ -341,6 +343,12 @@ int main(int argc, char **argv)
                                  CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
     cali_id_t ar_min_time_sec_attr  = cali_create_attribute("ar_min_time_sec", CALI_TYPE_DOUBLE,
                                  CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t bw_avg_time_sec_attr  = cali_create_attribute("bw_avg_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t bw_max_time_sec_attr  = cali_create_attribute("bw_max_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t bw_min_time_sec_attr  = cali_create_attribute("bw_min_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
 
     const char *src_dest_attributes = R"json(
         {
@@ -370,7 +378,10 @@ int main(int argc, char **argv)
                 {"expr": "any(max#red_min_time_sec)", "as" : "red_min_s"},
                 {"expr": "any(max#ar_avg_time_sec)", "as" : "ar_avg_s"},
                 {"expr": "any(max#ar_max_time_sec)", "as" : "ar_max_s"},
-                {"expr": "any(max#ar_min_time_sec)", "as" : "ar_min_s"}
+                {"expr": "any(max#ar_min_time_sec)", "as" : "ar_min_s"},
+                {"expr": "any(max#bw_avg_time_sec)", "as" : "bw_avg_s"},
+                {"expr": "any(max#bw_max_time_sec)", "as" : "bw_max_s"},
+                {"expr": "any(max#bw_min_time_sec)", "as" : "bw_min_s"}
                 ],
                 "group by": ["comm_phase"],
             },
@@ -394,7 +405,10 @@ int main(int argc, char **argv)
                 {"expr": "any(any#max#red_min_time_sec)", "as" : "red_min_s"},
                 {"expr": "any(any#max#ar_avg_time_sec)", "as" : "ar_avg_s"},
                 {"expr": "any(any#max#ar_max_time_sec)", "as" : "ar_max_s"},
-                {"expr": "any(any#max#ar_min_time_sec)", "as" : "ar_min_s"}
+                {"expr": "any(any#max#ar_min_time_sec)", "as" : "ar_min_s"},
+                {"expr": "any(any#max#bw_avg_time_sec)", "as" : "bw_avg_s"},
+                {"expr": "any(any#max#bw_max_time_sec)", "as" : "bw_max_s"},
+                {"expr": "any(any#max#bw_min_time_sec)", "as" : "bw_min_s"}
                 ],
                 "group by": ["comm_phase"],
             }
@@ -1312,6 +1326,282 @@ int main(int argc, char **argv)
                 MPI_Comm_free(&region_comm);
                 MPI_Barrier(MPI_COMM_WORLD);
             }
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // ===================== BANDWIDTH =====================
+        if (op == OpKind::Bandwidth || op == OpKind::All)
+        {
+            for (int partner_rank : partners)
+            {
+                std::string region_label = region_names[partner_rank];
+
+                std::vector<RankPair> pairs =
+                    build_pingpong_pairs(region_label,
+                                        size,
+                                        sys_cores_per_socket,
+                                        sys_cores_per_node,
+                                        pingpong_num_pairs);
+
+                if (pairs.empty()) {
+                    if (rank == 0)
+                        printf("Skipping region %s: no valid bandwidth pairs\n", region_label.c_str());
+                    continue;
+                }
+
+                std::map<int, int> src_to_dst;
+                std::map<int, int> dst_to_src;
+                std::set<int> active_ranks;
+
+                for (auto &p : pairs) {
+                    src_to_dst[p.src] = p.dst;
+                    dst_to_src[p.dst] = p.src;
+                    active_ranks.insert(p.src);
+                    active_ranks.insert(p.dst);
+                }
+
+                int active = active_ranks.count(rank) > 0;
+
+                MPI_Comm bw_comm = MPI_COMM_NULL;
+                MPI_Comm_split(MPI_COMM_WORLD, active ? 0 : MPI_UNDEFINED, rank, &bw_comm);
+
+                if (!active) {
+                    MPI_Barrier(MPI_COMM_WORLD);
+                    continue;
+                }
+
+                int bw_rank = 0;
+                MPI_Comm_rank(bw_comm, &bw_rank);
+
+                bool is_sender = src_to_dst.count(rank) > 0;
+                bool is_receiver = dst_to_src.count(rank) > 0;
+
+                int peer = MPI_PROC_NULL;
+                if (is_sender) {
+                    peer = src_to_dst[rank];
+                }
+                else if (is_receiver) {
+                    peer = dst_to_src[rank];
+                }
+
+                if (rank == 0)
+                {
+                    printf("\n--- Testing %s (BANDWIDTH) with %zu pairs ---\n", region_label.c_str(), pairs.size());
+
+                    for (auto &p : pairs) {
+                        printf("  one-way pair %d (%s) -> %d (%s)\n", p.src, all_hostnames[p.src], p.dst, all_hostnames[p.dst]);
+                    }
+                    fflush(stdout);
+
+#if defined(USE_CALIPER)
+                    cali_set_int(src_rank_attr, pairs[0].src);
+                    cali_set_int(dest_rank_attr, pairs[0].dst);
+                    cali_set_int(src_node_attr, extract_node_number(all_hostnames[pairs[0].src]));
+                    cali_set_int(dest_node_attr, extract_node_number(all_hostnames[pairs[0].dst]));
+#endif
+                }
+
+                const int base_tag = 3000 + ((partner_rank % 2000) * 10);
+                const int BW_TAG = base_tag;
+
+                int warmup = 1;
+                size_t bw_total_bytes = (size_t)WINDOW_SIZE * (size_t)message;
+
+                // ---------- buffer allocation ----------
+#if defined(USE_HIP)
+                char *send_flat = nullptr;
+                char *recv_flat = nullptr;
+
+                hipError_t err1 = hipMalloc((void**)&send_flat, bw_total_bytes);
+                hipError_t err2 = hipMalloc((void**)&recv_flat, bw_total_bytes);
+
+                if (err1 != hipSuccess || err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(err1), hipGetErrorString(err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                char *h_tmp = (char*)malloc(bw_total_bytes);
+                if (!h_tmp) {
+                    fprintf(stderr, "Rank %d host malloc failed for %zu bytes\n", rank, bw_total_bytes);
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                fill_with_random_pattern(h_tmp, bw_total_bytes);
+
+                hipError_t cuerr1 = hipMemcpy(send_flat, h_tmp, bw_total_bytes, hipMemcpyHostToDevice);
+                assert(cuerr1 == hipSuccess);
+                hipError_t cuerr2 = hipMemset(recv_flat, 0, bw_total_bytes);
+                assert(cuerr2 == hipSuccess);
+
+                free(h_tmp);
+
+#elif defined(USE_CUDA)
+                int dev_count = 0;
+                cuda_check(cudaGetDeviceCount(&dev_count));
+                cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
+
+                char *send_flat = nullptr;
+                char *recv_flat = nullptr;
+
+                cuda_check(cudaMalloc((void**)&send_flat, bw_total_bytes));
+                cuda_check(cudaMalloc((void**)&recv_flat, bw_total_bytes));
+
+                char *h_tmp = nullptr;
+                cuda_check(cudaMallocHost((void**)&h_tmp, bw_total_bytes));
+                fill_with_random_pattern(h_tmp, bw_total_bytes);
+                cuda_check(cudaMemcpy(send_flat, h_tmp, bw_total_bytes, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(recv_flat, 0, bw_total_bytes));
+                cuda_check(cudaFreeHost(h_tmp));
+
+#else
+                char *send_flat = (char*)malloc(bw_total_bytes);
+                char *recv_flat = (char*)malloc(bw_total_bytes);
+
+                if (!send_flat || !recv_flat) {
+                    fprintf(stderr, "Rank %d malloc failed for %zu bytes\n", rank, bw_total_bytes);
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                fill_with_random_pattern(send_flat, bw_total_bytes);
+                memset(recv_flat, 0, bw_total_bytes);
+#endif
+
+                std::vector<char*> s_buf(WINDOW_SIZE);
+                std::vector<char*> r_buf(WINDOW_SIZE);
+
+                for (int j = 0; j < WINDOW_SIZE; ++j) {
+                    s_buf[j] = send_flat + (size_t)j * (size_t)message;
+                    r_buf[j] = recv_flat + (size_t)j * (size_t)message;
+                }
+
+                std::vector<MPI_Request> requests(WINDOW_SIZE);
+
+                MPI_Barrier(bw_comm);
+
+                // ---------- warmup ----------
+                for (int i = 0; i < warmup; ++i)
+                {
+                    if (is_receiver) {
+                        for (int j = 0; j < WINDOW_SIZE; ++j) {
+                            MPI_Irecv(r_buf[j], message, MPI_CHAR, peer, BW_TAG + j, MPI_COMM_WORLD, &requests[j]);
+                        }
+                    }
+
+                    MPI_Barrier(bw_comm);
+
+                    if (is_sender) {
+                        for (int j = 0; j < WINDOW_SIZE; ++j) {
+                            MPI_Isend(s_buf[j], message, MPI_CHAR, peer, BW_TAG + j, MPI_COMM_WORLD, &requests[j]);
+                        }
+                        MPI_Waitall(WINDOW_SIZE, requests.data(), MPI_STATUSES_IGNORE);
+                    }
+                    if (is_receiver) {
+                        MPI_Waitall(WINDOW_SIZE, requests.data(), MPI_STATUSES_IGNORE);
+                    }
+
+                    MPI_Barrier(bw_comm);
+                }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_BEGIN(region_label.c_str());
+#endif
+
+                // ---------- timed bandwidth ----------
+                double total_time = 0.0;
+                double min_time = std::numeric_limits<double>::infinity();
+                double max_time = 0.0;
+                int iters = 0;
+
+                MPI_Barrier(bw_comm);
+
+                for (int i = 0; i < num_iterations; ++i)
+                {
+                    if (is_receiver) {
+                        for (int j = 0; j < WINDOW_SIZE; ++j) {
+                            MPI_Irecv(r_buf[j], message, MPI_CHAR, peer, BW_TAG + j, MPI_COMM_WORLD, &requests[j]);
+                        }
+                    }
+
+                    MPI_Barrier(bw_comm);
+
+                    if (is_sender) {
+                        double start = MPI_Wtime();
+                        for (int j = 0; j < WINDOW_SIZE; ++j) {
+                            MPI_Isend(s_buf[j], message, MPI_CHAR, peer, BW_TAG + j, MPI_COMM_WORLD, &requests[j]);
+                        }
+
+                        MPI_Waitall(WINDOW_SIZE, requests.data(), MPI_STATUSES_IGNORE);
+
+                        double end = MPI_Wtime();
+                        double dt = end - start;
+
+                        total_time += dt;
+                        if (dt < min_time) min_time = dt;
+                        if (dt > max_time) max_time = dt;
+                        ++iters;
+                    }
+
+                    if (is_receiver) {
+                        MPI_Waitall(WINDOW_SIZE, requests.data(), MPI_STATUSES_IGNORE);
+                    }
+
+                    MPI_Barrier(bw_comm);
+                }
+
+                double local_avg = 0.0;
+                double local_min = std::numeric_limits<double>::infinity();
+                double local_max = 0.0;
+
+                if (is_sender && iters > 0) {
+                    local_avg = total_time / iters;
+                    local_min = min_time;
+                    local_max = max_time;
+                }
+
+                double bandwidth_avg_time = 0.0;
+                double bandwidth_min_time = 0.0;
+                double bandwidth_max_time = 0.0;
+
+                MPI_Reduce(&local_avg, &bandwidth_avg_time, 1, MPI_DOUBLE, MPI_MAX, 0, bw_comm);
+                MPI_Reduce(&local_min, &bandwidth_min_time, 1, MPI_DOUBLE, MPI_MIN, 0, bw_comm);
+                MPI_Reduce(&local_max, &bandwidth_max_time, 1, MPI_DOUBLE, MPI_MAX, 0, bw_comm);
+
+                if (bw_rank == 0)
+                {
+#if defined(USE_CALIPER)
+                    cali_set_string(comm_phase_attr, "bandwidth");
+                    cali_set_double(bw_avg_time_sec_attr, bandwidth_avg_time);
+                    cali_set_double(bw_min_time_sec_attr, bandwidth_min_time);
+                    cali_set_double(bw_max_time_sec_attr, bandwidth_max_time);
+#endif
+
+                    printf("BANDWIDTH %s: avg=%g s, min=%g s, max=%g s\n", region_label.c_str(), bandwidth_avg_time, bandwidth_min_time, bandwidth_max_time);
+                    fflush(stdout);
+                }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_END(region_label.c_str());
+#endif
+
+                // ---------- cleanup ----------
+#if defined(USE_HIP)
+                hipFree(send_flat);
+                hipFree(recv_flat);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFree(send_flat));
+                cuda_check(cudaFree(recv_flat));
+#else
+                free(send_flat);
+                free(recv_flat);
+#endif
+
+                MPI_Comm_free(&bw_comm);
+                MPI_Barrier(MPI_COMM_WORLD);
+            }
+
+            if (rank == 0)
+                printf("Done with Bandwidth\n");
         }
 
 #if defined(USE_CALIPER)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -847,7 +847,7 @@ int main(int argc, char **argv)
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
 
-                fprintf("end warmup, begin timing");
+                printf("end warmup, begin timing");
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
@@ -895,7 +895,7 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
 #endif
-                fprintf("end timing");
+                printf("end timing");
 
 #if defined(USE_HIP)
                 free(aa_send_host);
@@ -911,7 +911,7 @@ int main(int argc, char **argv)
                 free(aa_send);
                 free(aa_recv);
 #endif
-                fprintf("freed memory");
+                printf("freed memory");
             }
         }
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -1121,6 +1121,23 @@ int main(int argc, char **argv)
             {
                 std::string region_label = region_names[partner_rank];
 
+                int ranks_in_region = partner_rank + 1;
+                int active = (rank < ranks_in_region);
+
+                MPI_Comm region_comm = MPI_COMM_NULL;
+                MPI_Comm_split(MPI_COMM_WORLD, active ? 0 : MPI_UNDEFINED, rank, &region_comm);     //making subcommunicators
+
+                if (!active)
+                {
+                    MPI_Barrier(MPI_COMM_WORLD);
+                    continue;
+                }
+
+                int region_rank = 0;
+                int region_size = 0;
+                MPI_Comm_rank(region_comm, &region_rank);
+                MPI_Comm_size(region_comm, &region_size);
+
                 size_t ar_count = static_cast<size_t>(message);
                 if (ar_count > INT_MAX) {
                     if (rank == 0) fprintf(stderr, "Allreduce count too large\n");
@@ -1128,6 +1145,11 @@ int main(int argc, char **argv)
                 }
                 int warmup = 1;
                 double ar_total_time = 0.0;
+
+                if (region_rank == 0) {
+                    printf("\n--- Testing %s (ALLREDUCE) with %d ranks ---\n", region_label.c_str(), region_size);
+                    fflush(stdout);
+                }
 
 #if defined(USE_CUDA)
                 char *ar_d_send=nullptr;
@@ -1184,14 +1206,14 @@ int main(int argc, char **argv)
                 {
 #if defined(USE_CUDA)
                     cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
                     cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
                     hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
                     hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
 #else
-                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
 #endif
                 }
 #if defined(USE_CALIPER)
@@ -1207,22 +1229,22 @@ int main(int argc, char **argv)
 
                 for(int i = 0; i < num_iterations; i++)
                 {
-                    MPI_Barrier(MPI_COMM_WORLD);
+                    MPI_Barrier(region_comm);
                     double t0 = MPI_Wtime();
 #if defined(USE_CUDA)
                     cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
                     cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
                     hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
                     hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
 #else
-                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
 #endif
                     double dt = MPI_Wtime() - t0;
                     double iter_max = 0.0;
-                    MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+                    MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, region_comm);
 
                     if(rank == 0)
                     {
@@ -1264,6 +1286,9 @@ int main(int argc, char **argv)
 #endif
                 printf("freed memory\n");
                 fflush(stdout);
+
+                MPI_Comm_free(&region_comm);
+                MPI_Barrier(MPI_COMM_WORLD);
             }
         }
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -55,7 +55,7 @@ const char *get_hostname_for_rank(int rank, char all_hostnames[][1024], int size
         return "INVALID_RANK";
 }
 
-int extract_node_number(const char *hostname)
+int extract_node_number(const char *hostname)       //helper function to build region labels
 {
     int len = (int)strlen(hostname);
     int num = 0;
@@ -99,6 +99,7 @@ struct RankPair {
     int dst;
 };
 
+//building region labels specifically for 1 node (same socket and different socket)
 static std::vector<RankPair>
 build_pingpong_pairs(const std::string& region_label,
                      int size,
@@ -274,13 +275,13 @@ int main(int argc, char **argv)
     if (rank == 0)
     {
         printf("Configuration:\n");
-        printf("PING_PONG_LIMIT: %d\n", num_iterations);
+        printf("Number iterations: %d\n", num_iterations);            //renamed for easier understanding
         printf("Message size: %d bytes\n", msg_size);
         printf("Cores per socket: %d\n", sys_cores_per_socket);
         printf("Cores per node: %d\n", sys_cores_per_node);
         printf("Nodes: %d\n", n_nodes);
         printf("World size: %d\n", size);
-        printf("Pingpong num pairs: %d\n", pingpong_num_pairs);
+        printf("Pingpong num pairs: %d\n", pingpong_num_pairs);       //only for Pingpong
         printf("Mode (-O): %s\n",
                op == OpKind::PingPong ? "pingpong" :
                op == OpKind::Alltoall ? "alltoall" :
@@ -414,7 +415,7 @@ int main(int argc, char **argv)
     int current_nodes = n_nodes;
     int current_p = P;
 
-    while (current_p > 2)
+    while (current_p > 2)                               //splitting for region labels for pingpong
     {
         int partner_rank = current_p - 1;
         std::string label;
@@ -487,13 +488,13 @@ int main(int argc, char **argv)
 
                 int partner = my_partner[rank];
 
-                // ---- CLEAN FIX #1: split communicator so only paired ranks participate ----
+                //split communicator so only paired ranks participate
                 const int active = (partner != MPI_PROC_NULL);
                 MPI_Comm pp_comm = MPI_COMM_NULL;
                 MPI_Comm_split(MPI_COMM_WORLD, active ? 0 : MPI_UNDEFINED, rank, &pp_comm);
 
                 if (!active) {
-                    // Not in any pair for this region: do NOT touch barriers inside this region
+                    //Not in any pair for this region: do NOT touch barriers inside this region
                     continue;
                 }
 
@@ -639,7 +640,6 @@ int main(int argc, char **argv)
                     }
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    //MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
 #endif
                 }
 
@@ -770,6 +770,7 @@ int main(int argc, char **argv)
                 int warmup = 1;
                 double alltoall_total_time = 0.0;
 
+                // --- buffer allocation ---
 #if defined(USE_HIP)
                 char *aa_send_dev;
                 char *aa_recv_dev;
@@ -820,6 +821,7 @@ int main(int argc, char **argv)
                 memset(aa_recv,  0, aa_total_bytes);
 #endif
 
+                // --- begin warmup ---
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region_aa);
 #endif
@@ -854,6 +856,7 @@ int main(int argc, char **argv)
                 double max_rtt = 0.0;
                 int iters = 0;
 
+                // --- timed alltoall ---
                 for (int it = 0; it < num_iterations; ++it)
                 {
                     MPI_Barrier(MPI_COMM_WORLD);
@@ -881,7 +884,7 @@ int main(int argc, char **argv)
                     if (rank == 0)
                     {
                         alltoall_total_time += iter_max;
-                        if(dt < min_rtt) min_rtt = dt;
+                        if(dt < min_rtt) min_rtt = dt;      //min & max not computing correctly on rank 0
                         if(dt > max_rtt) max_rtt = dt;
                         ++iters;
 
@@ -902,6 +905,7 @@ int main(int argc, char **argv)
                 printf("rank %d: end timing\n", rank);
                 fflush(stdout);
 
+                // --- freeing up memory ---
 #if defined(USE_HIP)
                 free(aa_send_host);
                 free(aa_recv_host);
@@ -939,6 +943,7 @@ int main(int argc, char **argv)
                 int warmup = 1;
                 double red_total_time = 0.0;
 
+                // --- buffer allocation ---
 #if defined(USE_CUDA)
                 char *rd_d_send=nullptr;
                 char *rd_d_recv=nullptr;
@@ -985,9 +990,13 @@ int main(int argc, char **argv)
                 memset(rd_recv, 0,   red_count);
 #endif
 
+                // --- warmup section ---
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region_red);
 #endif
+                printf("rank %d: begin warmup\n", rank);
+                fflush(stdout);
+
                 for (int i = 0; i < warmup; i++)
                 {
 #if defined(USE_CUDA)
@@ -1007,11 +1016,14 @@ int main(int argc, char **argv)
                 CALI_MARK_END(warmup_region_red);
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
+                printf("rank %d: end warmup, begin timing\n", rank);
+                fflush(stdout);
 
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
 
+                // --- timed reduce ---
                 for(int i = 0; i < num_iterations; i++)
                 {
                     MPI_Barrier(MPI_COMM_WORLD);
@@ -1034,7 +1046,7 @@ int main(int argc, char **argv)
                     if(rank == 0)
                     {
                         red_total_time += iter_max;
-                        if(dt < min_rtt) min_rtt = dt;
+                        if(dt < min_rtt) min_rtt = dt;      //fix min and max calculation
                         if(dt > max_rtt) max_rtt = dt;
                         ++iters;
 
@@ -1044,12 +1056,16 @@ int main(int argc, char **argv)
                         cali_set_double(red_avg_time_sec_attr, avg_rtt);
                         cali_set_double(red_max_time_sec_attr, max_rtt);
                         cali_set_double(red_min_time_sec_attr, min_rtt);
+                        printf("finished iteration: %d\n", i);
+                        fflush(stdout);
 #endif
                     }
                 }
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
 #endif
+                printf("rank %d: end timing\n", rank);
+                fflush(stdout);
 
 #if defined(USE_HIP)
                 free(rd_h_send);
@@ -1065,6 +1081,8 @@ int main(int argc, char **argv)
                 free(rd_send);
                 free(rd_recv);
 #endif
+                printf("freed memory\n");
+                fflush(stdout);
             }
         }
 
@@ -1133,6 +1151,9 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region_ar);
 #endif
+                printf("rank %d: begin warmup\n", rank);
+                fflush(stdout);
+
                 for (int i = 0; i < warmup; i++)
                 {
 #if defined(USE_CUDA)
@@ -1151,6 +1172,9 @@ int main(int argc, char **argv)
                 CALI_MARK_END(warmup_region_ar);
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
+                printf("rank %d: end warmup, begin timing\n", rank);
+                fflush(stdout);
+
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
@@ -1177,7 +1201,7 @@ int main(int argc, char **argv)
                     if(rank == 0)
                     {
                         ar_total_time += iter_max;
-                        if(dt < min_rtt) min_rtt = dt;
+                        if(dt < min_rtt) min_rtt = dt;          //fix min and max calculation
                         if(dt > max_rtt) max_rtt = dt;
                         ++iters;
 
@@ -1187,12 +1211,16 @@ int main(int argc, char **argv)
                         cali_set_double(ar_avg_time_sec_attr, avg_rtt);
                         cali_set_double(ar_max_time_sec_attr, max_rtt);
                         cali_set_double(ar_min_time_sec_attr, min_rtt);
+                        printf("finished iteration: %d\n", i);
+                        fflush(stdout);
 #endif
                     }
                 }
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
 #endif
+                printf("rank %d: end timing\n", rank);
+                fflush(stdout);
 
 #if defined(USE_HIP)
                 free(ar_h_send);
@@ -1208,6 +1236,8 @@ int main(int argc, char **argv)
                 free(ar_send);
                 free(ar_recv);
 #endif
+                printf("freed memory\n");
+                fflush(stdout);
             }
         }
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -618,12 +618,17 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
+                    printf("before MPI_Barrier before inside warmup");
                     MPI_Barrier(MPI_COMM_WORLD);
+                    printf("after MPI_Barrier before waitall inside warmup");
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    printf("After Waitall warmup");
 #endif
                 }
+                printf("before MPI_Barrier outside warmup");
                 MPI_Barrier(MPI_COMM_WORLD);
+                printf("after MPI_Barrier outside warmup");
 
 #if defined(USE_CALIPER)
                 CALI_MARK_END(warmup_region);
@@ -679,9 +684,12 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
+                    printf("before MPI_Barrier inside iteration");
                     MPI_Barrier(MPI_COMM_WORLD);
+                    printf("after MPI_barrier before waitall inside iteration");
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    printf("After MPI_Waitall");
 #endif
 
                     if (i_am_timing_rank) {
@@ -693,7 +701,9 @@ int main(int argc, char **argv)
                         ++iters;
                     }
                 }
+                printf("before MPI_Barrier outside iteration loop");
                 MPI_Barrier(MPI_COMM_WORLD);
+                printf("after MPI_Barrier outside iteration loop");
 
                 if (i_am_timing_rank)
                 {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -434,7 +434,7 @@ int main(int argc, char **argv)
         region_names[1] = "Same Node Same Socket";
     }
 
-    for (int message = msg_size; message <= pow(msg_size, 6); message *= 8)
+    for (int message = msg_size; message <= pow(msg_size, 11); message *= 8)
     {
 #if defined(USE_CALIPER)
         std::string profile = "spot(output=" + std::to_string(message) + "_" +

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -434,7 +434,7 @@ int main(int argc, char **argv)
         region_names[1] = "Same Node Same Socket";
     }
 
-    for (int message = msg_size; message <= pow(msg_size, 11); message *= 8)
+    for (int message = msg_size; message <= pow(msg_size, 6); message *= 8)
     {
 #if defined(USE_CALIPER)
         std::string profile = "spot(output=" + std::to_string(message) + "_" +

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -823,6 +823,7 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region_aa);
 #endif
+                fprintf("begin warmup");
 
                 for (int i = 0; i < warmup; i++)
                 {
@@ -846,6 +847,7 @@ int main(int argc, char **argv)
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
 
+                fprintf("end warmup, begin timing");
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
@@ -893,6 +895,7 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
 #endif
+                fprintf("end timing");
 
 #if defined(USE_HIP)
                 free(aa_send_host);
@@ -908,6 +911,7 @@ int main(int argc, char **argv)
                 free(aa_send);
                 free(aa_recv);
 #endif
+                fprintf("freed memory");
             }
         }
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -24,8 +24,8 @@
 
 #ifndef USE_CALIPER
 #define CALI_CXX_MARK_FUNCTION
-#define CALI_MARK_BEGIN(x)
-#define CALI_MARK_END(x)
+#define CALI_MARK_BEGIN(...)
+#define CALI_MARK_END(...)
 #endif
 
 #if defined(USE_HIP)
@@ -43,112 +43,156 @@ inline void cuda_check(cudaError_t e) {
 }
 #endif
 
-// ------------ helpers ------------
-static int extract_node_number(const char *hostname) {
-    int len = (int)strlen(hostname);
-    int num = 0, factor = 1;
-    for (int i = len - 1; i >= 0; --i) {
-        if (hostname[i] >= '0' && hostname[i] <= '9') {
+// ---- Operation selector (default: PingPong) ----
+enum class OpKind { All, PingPong, Alltoall, Reduce, Allreduce };
+
+const char *get_hostname_for_rank(int rank, char all_hostnames[][1024],
+                                  int size)
+{
+    if (rank >= 0 && rank < size)
+        return all_hostnames[rank];
+    else
+        return "INVALID_RANK";
+}
+
+int extract_node_number(const char *hostname)
+{
+    int len = strlen(hostname);
+    int num = 0;
+    int factor = 1;
+    for (int i = len - 1; i >= 0; --i)
+    {
+        if (hostname[i] >= '0' && hostname[i] <= '9')
+        {
             num += (hostname[i] - '0') * factor;
             factor *= 10;
-        } else break;
+        }
+        else
+        {
+            break;
+        }
     }
     return num;
 }
 
-enum class OpKind { PingPong, Alltoall, Reduce, Allreduce };
-
-static OpKind parse_opkind(const char* s) {
-    if (!s) return OpKind::PingPong;
-    std::string m(s);
-    if (m == "pingpong")  return OpKind::PingPong;
-    if (m == "alltoall")  return OpKind::Alltoall;
-    if (m == "reduce")    return OpKind::Reduce;
-    if (m == "allreduce") return OpKind::Allreduce;
-    fprintf(stderr, "Unknown -O option '%s' (use pingpong|alltoall|reduce|allreduce)\n", s);
-    MPI_Abort(MPI_COMM_WORLD, 2);
-    return OpKind::PingPong;
-}
-
-// ------------ main ------------
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
     int rank, size;
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-    // gather hostnames to rank 0 for printing/adiak
     char my_hostname[1024];
     gethostname(my_hostname, 1023);
     my_hostname[1023] = '\0';
-    std::vector<char> all_hostnames;
-    if (rank == 0) all_hostnames.resize(1024 * size, 0);
-    MPI_Gather(my_hostname, 1024, MPI_CHAR,
-               rank==0? all_hostnames.data():nullptr, 1024, MPI_CHAR, 0, MPI_COMM_WORLD);
-    auto host = [&](int r){ return rank==0? &all_hostnames[r*1024] : my_hostname; };
+    char all_hostnames[size][1024];
+    MPI_Gather(my_hostname, 1024, MPI_CHAR, all_hostnames, 1024, MPI_CHAR, 0,
+               MPI_COMM_WORLD);
 
 #if defined(USE_CALIPER)
-    static std::map<int, cali::ConfigManager> mgr;
     std::vector<std::string> all_comm_pairs;
+    static std::map<int, cali::ConfigManager> mgr;
     MPI_Comm adiak_comm = MPI_COMM_WORLD;
     adiak::init(&adiak_comm);
     adiak::collect_all();
     CALI_CXX_MARK_FUNCTION;
 #endif
 
-    // params
     int PING_PONG_LIMIT = 10;
     int msg_size = 1;
     int n_nodes = 1;
     int sys_cores_per_socket = 1;
     int sys_cores_per_node = 1;
     std::string metadata;
-    OpKind op = OpKind::PingPong;
-
-    const char *warmup_region    = "warmup";
+    const char *warmup_region = "warmup";
     const char *warmup_region_aa = "warmup_aa";
-    const char *warmup_region_red= "warmup_red";
+    const char *warmup_region_red = "warmup_red";
     const char *warmup_region_ar = "warmup_ar";
 
-    const char *usage =
-        "Usage: %s [-h] [-i iters] [-m msg_sz] [-n n_nodes] [-s cores/socket] [-c cores/node] [-b metadata] "
-        "[-O pingpong|alltoall|reduce|allreduce]\n";
+    // ---- default to PingPong ----
+    OpKind op = OpKind::PingPong;
 
     int opt;
-    while ((opt = getopt(argc, argv, "hi:m:n:s:c:b:O:")) != -1) {
-        switch (opt) {
-            case 'h': if (rank==0) printf(usage, argv[0]); MPI_Finalize(); return 0;
-            case 'i': PING_PONG_LIMIT = atoi(optarg); break;
-            case 'm': msg_size = atoi(optarg); break;
-            case 'n': n_nodes = atoi(optarg); break;
-            case 's': sys_cores_per_socket = atoi(optarg); break;
-            case 'c': sys_cores_per_node = atoi(optarg); break;
-            case 'b': metadata = optarg; break;
-            case 'O': op = parse_opkind(optarg); break;
-            default:  if (rank==0) printf(usage, argv[0]); MPI_Abort(MPI_COMM_WORLD, 1);
+    const char *usage =
+        "Usage: %s [-h] [-i n-iterations] [-p rank1,rank2] [-m msg_sz] "
+        "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] [-b metadata] "
+        "[-O pingpong|alltoall|reduce|allreduce|all]\n"
+        "Default: -O pingpong\n";
+
+    // add 'O:' to parse the selector
+    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:O:")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                printf(usage, argv[0]);
+                MPI_Finalize();
+                return 0;
+            case 'i':
+                PING_PONG_LIMIT = atoi(optarg);
+                break;
+            case 'p':
+                // kept for compatibility; you can parse partners here if desired
+                break;
+            case 'm':
+                msg_size = atoi(optarg);
+                break;
+            case 'n':
+                n_nodes = atoi(optarg);
+                break;
+            case 's':
+                sys_cores_per_socket = atoi(optarg);
+                break;
+            case 'c':
+                sys_cores_per_node = atoi(optarg);
+                break;
+            case 'b':
+                metadata = optarg;
+                break;
+            case 'O':
+            {
+                std::string s = optarg ? std::string(optarg) : std::string();
+                if (s == "pingpong")      op = OpKind::PingPong;
+                else if (s == "alltoall") op = OpKind::Alltoall;
+                else if (s == "reduce")   op = OpKind::Reduce;
+                else if (s == "allreduce")op = OpKind::Allreduce;
+                else if (s == "all")      op = OpKind::All;
+                else {
+                    if (rank == 0)
+                        fprintf(stderr, "Unknown -O value '%s'. Expected pingpong|alltoall|reduce|allreduce|all\n", s.c_str());
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+                break;
+            }
+            default:
+                if (rank == 0) printf(usage, argv[0]);
+                MPI_Abort(MPI_COMM_WORLD, 1);
         }
     }
 
-    if (rank == 0) {
+    if (rank == 0)
+    {
         printf("Configuration:\n");
-        printf("Operation: %s\n",
-               op==OpKind::PingPong ? "pingpong" :
-               op==OpKind::Alltoall ? "alltoall" :
-               op==OpKind::Reduce   ? "reduce"   : "allreduce");
         printf("PING_PONG_LIMIT: %d\n", PING_PONG_LIMIT);
         printf("Message size: %d bytes\n", msg_size);
         printf("Cores per socket: %d\n", sys_cores_per_socket);
         printf("Cores per node: %d\n", sys_cores_per_node);
         printf("Nodes: %d\n", n_nodes);
         printf("World size: %d\n", size);
+        printf("Mode (-O): %s\n",
+               op == OpKind::PingPong ? "pingpong" :
+               op == OpKind::Alltoall ? "alltoall" :
+               op == OpKind::Reduce   ? "reduce" :
+               op == OpKind::Allreduce? "allreduce" : "all");
 
 #if defined(USE_CALIPER)
-        // rank->host map
         std::stringstream rankmap;
         rankmap << "{";
-        for (int i = 0; i < size; ++i) {
-            rankmap << "\"" << i << "\": \"" << (&all_hostnames[i*1024])[0] << "\"";
-            if (i < size - 1) rankmap << ", ";
+        for (int i = 0; i < size; ++i)
+        {
+            rankmap << "\"" << i << "\": \"" << all_hostnames[i] << "\"";
+            if (i < size - 1)
+                rankmap << ", ";
         }
         rankmap << "}";
         adiak::value("rank_node_map", rankmap.str());
@@ -157,25 +201,42 @@ int main(int argc, char **argv) {
     }
 
 #if defined(USE_CALIPER)
-    // attributes
-    cali_id_t src_rank_attr = cali_create_attribute("src_rank", CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t dest_rank_attr= cali_create_attribute("dest_rank",CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t src_node_attr = cali_create_attribute("src_node", CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t dest_node_attr= cali_create_attribute("dest_node",CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t message_size_attr = cali_create_attribute("message_size_bytes", CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t comm_phase_attr   = cali_create_attribute("comm_phase",        CALI_TYPE_STRING, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t aa_avg_time_sec_attr = cali_create_attribute("aa_avg_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t aa_max_time_sec_attr = cali_create_attribute("aa_max_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t aa_min_time_sec_attr = cali_create_attribute("aa_min_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t pp_avg_time_sec_attr = cali_create_attribute("pp_avg_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t pp_max_time_sec_attr = cali_create_attribute("pp_max_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t pp_min_time_sec_attr = cali_create_attribute("pp_min_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t red_avg_time_sec_attr= cali_create_attribute("red_avg_time_sec",CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t red_max_time_sec_attr= cali_create_attribute("red_max_time_sec",CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t red_min_time_sec_attr= cali_create_attribute("red_min_time_sec",CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t ar_avg_time_sec_attr = cali_create_attribute("ar_avg_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t ar_max_time_sec_attr = cali_create_attribute("ar_max_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
-    cali_id_t ar_min_time_sec_attr = cali_create_attribute("ar_min_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t src_rank_attr = cali_create_attribute("src_rank", CALI_TYPE_INT,
+                              CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t dest_rank_attr = cali_create_attribute("dest_rank", CALI_TYPE_INT,
+                               CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t src_node_attr = cali_create_attribute("src_node", CALI_TYPE_INT,
+                              CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t dest_node_attr = cali_create_attribute("dest_node", CALI_TYPE_INT,
+                               CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t message_size_attr = cali_create_attribute("message_size_bytes",
+                                  CALI_TYPE_INT, CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t comm_phase_attr = cali_create_attribute("comm_phase", CALI_TYPE_STRING,
+                                CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t aa_avg_time_sec_attr = cali_create_attribute("aa_avg_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t aa_max_time_sec_attr = cali_create_attribute("aa_max_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t aa_min_time_sec_attr = cali_create_attribute("aa_min_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t pp_avg_time_sec_attr = cali_create_attribute("pp_avg_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t pp_max_time_sec_attr = cali_create_attribute("pp_max_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t pp_min_time_sec_attr = cali_create_attribute("pp_min_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t red_avg_time_sec_attr = cali_create_attribute("red_avg_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t red_max_time_sec_attr = cali_create_attribute("red_max_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t red_min_time_sec_attr = cali_create_attribute("red_min_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t ar_avg_time_sec_attr  = cali_create_attribute("ar_avg_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t ar_max_time_sec_attr  = cali_create_attribute("ar_max_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t ar_min_time_sec_attr  = cali_create_attribute("ar_min_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
 
     const char *src_dest_attributes = R"json(
         {
@@ -183,56 +244,59 @@ int main(int argc, char **argv) {
             "type": "boolean",
             "category": "metric",
             "description": "Collect pingpong attributes",
-            "query": [
-                {
-                    "level": "local",
-                    "select": [
-                        {"expr": "any(max#src_rank)", "as": "src_rank"},
-                        {"expr": "any(max#dest_rank)", "as": "dest_rank"},
-                        {"expr": "any(max#src_node)", "as": "src_node"},
-                        {"expr": "any(max#dest_node)", "as": "dest_node"},
-                        {"expr": "any(max#message_size_bytes)", "as": "message_size_bytes"},
-                        {"expr": "any(max#aa_avg_time_sec)", "as" : "aa_avg_s"},
-                        {"expr": "any(max#aa_max_time_sec)", "as" : "aa_max_s"},
-                        {"expr": "any(max#aa_min_time_sec)", "as" : "aa_min_s"},
-                        {"expr": "any(max#pp_avg_time_sec)", "as" : "pp_avg_s"},
-                        {"expr": "any(max#pp_max_time_sec)", "as" : "pp_max_s"},
-                        {"expr": "any(max#pp_min_time_sec)", "as" : "pp_min_s"},
-                        {"expr": "any(max#red_avg_time_sec)", "as" : "red_avg_s"},
-                        {"expr": "any(max#red_max_time_sec)", "as" : "red_max_s"},
-                        {"expr": "any(max#red_min_time_sec)", "as" : "red_min_s"},
-                        {"expr": "any(max#ar_avg_time_sec)", "as" : "ar_avg_s"},
-                        {"expr": "any(max#ar_max_time_sec)", "as" : "ar_max_s"},
-                        {"expr": "any(max#ar_min_time_sec)", "as" : "ar_min_s"}
-                    ],
-                    "group by": ["comm_phase"]
-                },
-                {
-                    "level": "cross",
-                    "select": [
-                        {"expr": "any(any#max#src_rank)", "as": "src_rank"},
-                        {"expr": "any(any#max#dest_rank)", "as": "dest_rank"},
-                        {"expr": "any(any#max#src_node)", "as": "src_node"},
-                        {"expr": "any(any#max#dest_node)", "as": "dest_node"},
-                        {"expr": "any(any#max#message_size_bytes)", "as": "message_size_bytes"},
-                        {"expr": "any(any#max#aa_avg_time_sec)", "as" : "aa_avg_s"},
-                        {"expr": "any(any#max#aa_max_time_sec)", "as" : "aa_max_s"},
-                        {"expr": "any(any#max#aa_min_time_sec)", "as" : "aa_min_s"},
-                        {"expr": "any(any#max#pp_avg_time_sec)", "as" : "pp_avg_s"},
-                        {"expr": "any(any#max#pp_max_time_sec)", "as" : "pp_max_s"},
-                        {"expr": "any(any#max#pp_min_time_sec)", "as" : "pp_min_s"},
-                        {"expr": "any(any#max#red_avg_time_sec)", "as" : "red_avg_s"},
-                        {"expr": "any(any#max#red_max_time_sec)", "as" : "red_max_s"},
-                        {"expr": "any(any#max#red_min_time_sec)", "as" : "red_min_s"},
-                        {"expr": "any(any#max#ar_avg_time_sec)", "as" : "ar_avg_s"},
-                        {"expr": "any(any#max#ar_max_time_sec)", "as" : "ar_max_s"},
-                        {"expr": "any(any#max#ar_min_time_sec)", "as" : "ar_min_s"}
-                    ],
-                    "group by": ["comm_phase"]
-                }
+            "query":
+            [
+            {
+                "level": "local",
+                "select":
+                [
+                {"expr": "any(max#src_rank)", "as": "src_rank"},
+                {"expr": "any(max#dest_rank)", "as": "dest_rank"},
+                {"expr": "any(max#src_node)", "as": "src_node"},
+                {"expr": "any(max#dest_node)", "as": "dest_node"},
+                {"expr": "any(max#message_size_bytes)", "as": "message_size_bytes"},
+                {"expr": "any(max#aa_avg_time_sec)", "as" : "aa_avg_s"},
+                {"expr": "any(max#aa_max_time_sec)", "as" : "aa_max_s"},
+                {"expr": "any(max#aa_min_time_sec)", "as" : "aa_min_s"},
+                {"expr": "any(max#pp_avg_time_sec)", "as" : "pp_avg_s"},
+                {"expr": "any(max#pp_max_time_sec)", "as" : "pp_max_s"},
+                {"expr": "any(max#pp_min_time_sec)", "as" : "pp_min_s"},
+                {"expr": "any(max#red_avg_time_sec)", "as" : "red_avg_s"},
+                {"expr": "any(max#red_max_time_sec)", "as" : "red_max_s"},
+                {"expr": "any(max#red_min_time_sec)", "as" : "red_min_s"},
+                {"expr": "any(max#ar_avg_time_sec)", "as" : "ar_avg_s"},
+                {"expr": "any(max#ar_max_time_sec)", "as" : "ar_max_s"},
+                {"expr": "any(max#ar_min_time_sec)", "as" : "ar_min_s"}
+                ],
+                "group by": ["comm_phase"],
+            },
+            {
+                "level": "cross",
+                "select":
+                [
+                {"expr": "any(any#max#src_rank)", "as": "src_rank"},
+                {"expr": "any(any#max#dest_rank)", "as": "dest_rank"},
+                {"expr": "any(any#max#src_node)", "as": "src_node"},
+                {"expr": "any(any#max#dest_node)", "as": "dest_node"},
+                {"expr": "any(any#max#message_size_bytes)", "as": "message_size_bytes"},
+                {"expr": "any(any#max#aa_avg_time_sec)", "as" : "aa_avg_s"},
+                {"expr": "any(any#max#aa_max_time_sec)", "as" : "aa_max_s"},
+                {"expr": "any(any#max#aa_min_time_sec)", "as" : "aa_min_s"},
+                {"expr": "any(any#max#pp_avg_time_sec)", "as" : "pp_avg_s"},
+                {"expr": "any(any#max#pp_max_time_sec)", "as" : "pp_max_s"},
+                {"expr": "any(any#max#pp_min_time_sec)", "as" : "pp_min_s"},
+                {"expr": "any(any#max#red_avg_time_sec)", "as" : "red_avg_s"},
+                {"expr": "any(any#max#red_max_time_sec)", "as" : "red_max_s"},
+                {"expr": "any(any#max#red_min_time_sec)", "as" : "red_min_s"},
+                {"expr": "any(any#max#ar_avg_time_sec)", "as" : "ar_avg_s"},
+                {"expr": "any(any#max#ar_max_time_sec)", "as" : "ar_max_s"},
+                {"expr": "any(any#max#ar_min_time_sec)", "as" : "ar_min_s"}
+                ],
+                "group by": ["comm_phase"],
+            }
             ]
         }
-    )json";
+        )json";
 #endif
 
     auto now = std::chrono::system_clock::now();
@@ -240,436 +304,694 @@ int main(int argc, char **argv) {
     std::stringstream timestamp;
     timestamp << std::put_time(std::localtime(&now_time), "%Y%m%d_%H%M%S");
 
-    // Build partner list for pingpong (0 <-> last rank of each bucket)
     int P = sys_cores_per_node * n_nodes;
     std::vector<int> partners;
-    std::map<int,std::string> region_names;
+    std::map<int, std::string> region_names;
+
     int current_nodes = n_nodes;
     int current_p = P;
-    while (current_p > 2) {
+
+    while (current_p > 2)
+    {
         int partner_rank = current_p - 1;
-        std::string label = (current_nodes >= 2) ? std::to_string(current_nodes) + " nodes"
-                                                 : "Same Node Different Socket";
-        if (partner_rank > 0 && partner_rank < size) {
+        std::string label;
+        if (current_nodes >= 2)
+            label = std::to_string(current_nodes) + " nodes";
+        else
+            label = "Same Node Different Socket";
+
+        if (partner_rank > 0 && partner_rank < size)
+        {
             partners.push_back(partner_rank);
             region_names[partner_rank] = label;
         }
-        current_nodes /= 2;
+        current_nodes = current_nodes / 2;
         current_p = current_nodes * sys_cores_per_node;
     }
-    if (size > 1) {
+
+    // Always add same node same socket as 0 <-> 1
+    if (1 < size)
+    {
         partners.push_back(1);
         region_names[1] = "Same Node Same Socket";
     }
 
-    // sweep message sizes
-    for (int message = msg_size; message <= (int)std::pow((double)msg_size, 6.0); message *= 8) {
+    for (int message = msg_size; message <= pow(msg_size, 6); message *= 8)
+    {
 #if defined(USE_CALIPER)
-        std::string profile = "spot(output=" + std::to_string(message) + "_" + timestamp.str()
-                            + ".cali, profile.mpi)"
-                            + (metadata.empty() ? "" : (",metadata(file=" + metadata + ")"))
-                            + ",metadata(file=/etc/node_info.json,keys=\"host.os\")";
+        std::string profile = "spot(output=" + std::to_string(message) + "_" +
+                              timestamp.str() +
+                              ".cali, profile.mpi),metadata(file=" + metadata +
+                              "),metadata(file=/etc/node_info.json,keys=\"host.os\")";
+
+        cali_set_int(message_size_attr, message);
+
         mgr[message].add_option_spec(src_dest_attributes);
         mgr[message].set_default_parameter("pingpong_attributes", "true");
-        cali_set_int(message_size_attr, message);
         adiak::value("message_size", message);
         mgr[message].add(profile.c_str());
         mgr[message].start();
 #endif
 
-        // ---------------- PINGPONG (selected) ----------------
-        if (op == OpKind::PingPong) {
-            for (int partner_rank : partners) {
-                if (rank != 0 && rank != partner_rank) continue;
-
+        // ===================== PINGPONG =====================
+        if (op == OpKind::PingPong || op == OpKind::All)
+        {
+            for (int partner_rank : partners)
+            {
                 std::string region_label = region_names[partner_rank];
-                if (rank == 0) {
-                    printf("\n--- PINGPONG %s: 0 (%s) <-> %d (%s), msg=%d ---\n",
+
+                if (rank != 0 && rank != partner_rank)
+                    continue;
+
+                if (rank == 0)
+                {
+                    printf("\n--- Testing %s (PINGPONG) between ranks 0 (%s) and %d (%s) ---\n",
                            region_label.c_str(),
-                           &all_hostnames[0],
-                           partner_rank, &all_hostnames[partner_rank*1024], message);
+                           all_hostnames[0], partner_rank, all_hostnames[partner_rank]);
+
 #if defined(USE_CALIPER)
-                    std::string comm_pair = "0(" + std::string(&all_hostnames[0]) + ")<->" +
-                                            std::to_string(partner_rank) + "(" + std::string(&all_hostnames[partner_rank*1024]) + ")";
+                    std::string comm_pair = "0(" + std::string(all_hostnames[0]) + ")<->" +
+                                            std::to_string(partner_rank) + "(" + std::string(all_hostnames[partner_rank]) +
+                                            ")";
                     all_comm_pairs.push_back(comm_pair);
+
                     cali_set_int(src_rank_attr, 0);
                     cali_set_int(dest_rank_attr, partner_rank);
-                    cali_set_int(src_node_attr, extract_node_number(&all_hostnames[0]));
-                    cali_set_int(dest_node_attr, extract_node_number(&all_hostnames[partner_rank*1024]));
+                    cali_set_int(src_node_attr, extract_node_number(all_hostnames[0]));
+                    cali_set_int(dest_node_attr, extract_node_number(all_hostnames[partner_rank]));
 #endif
                 }
 
-                int warmup = 1;
                 double total_time = 0.0;
+                int warmup = 1;
+
+#if defined(USE_HIP)
+                char *send_buf;
+                char *recv_buf;
+
+                hipError_t err1 = hipMalloc((void**)&send_buf, message);
+                hipError_t err2 = hipMalloc((void**)&recv_buf, message);
+
+                if (err1 != hipSuccess || err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(err1), hipGetErrorString(err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                hipError_t cuerr1 = hipMemset(send_buf, 'a', message);
+                assert(cuerr1 == hipSuccess);
+                hipError_t cuerr2 = hipMemset(recv_buf, 0, message);
+                assert(cuerr2 == hipSuccess);
+#elif defined(USE_CUDA)
+                int dev_count = 0;
+                cuda_check(cudaGetDeviceCount(&dev_count));
+                cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
+
+                char *d_send = nullptr;
+                char *d_recv = nullptr;
+                cuda_check(cudaMalloc((void**)&d_send, message));
+                cuda_check(cudaMalloc((void**)&d_recv, message));
+                cuda_check(cudaMemset(d_send, 'a', message));
+                cuda_check(cudaMemset(d_recv, 0, message));
+
+                char *h_send = nullptr, *h_recv = nullptr;
+                cuda_check(cudaMallocHost((void**)&h_send, message));
+                cuda_check(cudaMallocHost((void**)&h_recv, message));
+                memset(h_send, 'a', message);
+                memset(h_recv, 0, message);
+#else
+                char *send_buf = (char *)malloc(message);
+                char *recv_buf = (char *)malloc(message);
+                memset(send_buf, 'a', message);
+                memset(recv_buf, 0, message);
+#endif
+
+#if defined(USE_CALIPER)
+                CALI_MARK_BEGIN(warmup_region);
+#endif
+
+                for (int i = 0; i < warmup; i++)
+                {
+                    if (rank == 0)
+                    {
+#if defined(USE_HIP)
+                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+#elif defined(USE_CUDA)
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+#else
+                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+#endif
+                    }
+                    else if (rank == partner_rank)
+                    {
+#if defined(USE_HIP)
+                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+#elif defined(USE_CUDA)
+                        MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+#else
+                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+#endif
+                    }
+                }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_END(warmup_region);
+                CALI_MARK_BEGIN(region_label.c_str());
+#endif
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
 
-#if defined(USE_HIP)
-                char *send_buf; char *recv_buf;
-                hipMalloc((void**)&send_buf, message); hipMalloc((void**)&recv_buf, message);
-                hipMemset(send_buf,'a',message); hipMemset(recv_buf,0,message);
-#elif defined(USE_CUDA)
-                int dev_count=0; cuda_check(cudaGetDeviceCount(&dev_count));
-                cuda_check(cudaSetDevice(rank % (dev_count>0?dev_count:1)));
-                char *d_send=nullptr,*d_recv=nullptr; cuda_check(cudaMalloc((void**)&d_send,message));
-                cuda_check(cudaMalloc((void**)&d_recv,message));
-                cuda_check(cudaMemset(d_send,'a',message)); cuda_check(cudaMemset(d_recv,0,message));
-                char *h_send=nullptr,*h_recv=nullptr;
-                cuda_check(cudaMallocHost((void**)&h_send,message));
-                cuda_check(cudaMallocHost((void**)&h_recv,message));
-                memset(h_send,'a',message); memset(h_recv,0,message);
+                for (int i = 0; i < PING_PONG_LIMIT; i++)
+                {
+                    if (rank == 0)
+                    {
+#if defined(USE_CUDA)
+                        double start = MPI_Wtime();
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        double end = MPI_Wtime();
 #else
-                char *send_buf=(char*)malloc(message), *recv_buf=(char*)malloc(message);
-                memset(send_buf,'a',message); memset(recv_buf,0,message);
+                        double start = MPI_Wtime();
+                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        double end = MPI_Wtime();
 #endif
+                        double rtt = end - start;
+                        total_time += rtt;
 
-                CALI_MARK_BEGIN(warmup_region);
-                for (int i=0;i<warmup;i++) {
-                    if (rank==0) {
-#if defined(USE_CUDA)
-                        cuda_check(cudaMemcpy(h_send,d_send,message,cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
-                        MPI_Recv(h_recv,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv,h_recv,message,cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                        MPI_Send(send_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
-#else
-                        MPI_Send(send_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
-#endif
-                    } else {
-#if defined(USE_CUDA)
-                        MPI_Recv(h_recv,message,MPI_CHAR,0,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv,h_recv,message,cudaMemcpyHostToDevice));
-                        cuda_check(cudaMemcpy(h_send,d_send,message,cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send,message,MPI_CHAR,0,0,MPI_COMM_WORLD);
-#else
-                        MPI_Recv(recv_buf,message,MPI_CHAR,0,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf,message,MPI_CHAR,0,0,MPI_COMM_WORLD);
-#endif
-                    }
-                }
-                CALI_MARK_END(warmup_region);
-
-                CALI_MARK_BEGIN(region_label.c_str());
-                for (int i=0;i<PING_PONG_LIMIT;i++) {
-                    if (rank==0) {
-                        double t0 = MPI_Wtime();
-#if defined(USE_CUDA)
-                        cuda_check(cudaMemcpy(h_send,d_send,message,cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
-                        MPI_Recv(h_recv,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv,h_recv,message,cudaMemcpyHostToDevice));
-#else
-                        MPI_Send(send_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
-#endif
-                        double dt = MPI_Wtime() - t0;
-                        total_time += dt;
-                        if (dt<min_rtt) min_rtt=dt;
-                        if (dt>max_rtt) max_rtt=dt;
+                        if(rtt < min_rtt) min_rtt = rtt;
+                        if(rtt > max_rtt) max_rtt = rtt;
                         ++iters;
-                    } else {
+
+                    }
+                    else if (rank == partner_rank)
+                    {
 #if defined(USE_CUDA)
-                        MPI_Recv(h_recv,message,MPI_CHAR,0,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv,h_recv,message,cudaMemcpyHostToDevice));
-                        cuda_check(cudaMemcpy(h_send,d_send,message,cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send,message,MPI_CHAR,0,0,MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 #else
-                        MPI_Recv(recv_buf,message,MPI_CHAR,0,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf,message,MPI_CHAR,0,0,MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 #endif
                     }
                 }
-                CALI_MARK_END(region_label.c_str());
 
-                if (rank==0) {
-                    double avg_rtt = iters ? total_time / iters : 0.0;
+                if(rank == 0)
+                {
+                    double avg_rtt = (iters > 0) ? (total_time / iters) : 0.0;
 #if defined(USE_CALIPER)
                     cali_set_string(comm_phase_attr, "pingpong");
                     cali_set_double(pp_avg_time_sec_attr, avg_rtt);
                     cali_set_double(pp_max_time_sec_attr, max_rtt);
                     cali_set_double(pp_min_time_sec_attr, min_rtt);
 #endif
-                    double avg_latency_us = (avg_rtt*1e6)/2.0;
-                    double min_latency_us = (min_rtt*1e6)/2.0;
-                    double max_latency_us = (max_rtt*1e6)/2.0;
-                    printf("[PINGPONG] msg=%d  RTT avg=%.6f s min=%.6f s max=%.6f s | latency(one-way) avg=%.1f us min=%.1f us max=%.1f us\n",
-                           message, avg_rtt, min_rtt, max_rtt, avg_latency_us, min_latency_us, max_latency_us);
                 }
 
-#if defined(USE_HIP)
-                hipFree(send_buf); hipFree(recv_buf);
-#elif defined(USE_CUDA)
-                cuda_check(cudaFreeHost(h_send)); cuda_check(cudaFreeHost(h_recv));
-                cuda_check(cudaFree(d_send));     cuda_check(cudaFree(d_recv));
-#else
-                free(send_buf); free(recv_buf);
+#if defined(USE_CALIPER)
+                CALI_MARK_END(region_label.c_str());
 #endif
-                MPI_Barrier(MPI_COMM_WORLD);
-            } // partners
-        } // end pingpong
-
-        // ---------------- ALLTOALL (selected) ----------------
-        if (op == OpKind::Alltoall) {
-            size_t count_per_rank = (size_t)message;
-            size_t total_bytes = count_per_rank * (size_t)size;
-            int warmup = 1;
-            double total=0.0, min_t=std::numeric_limits<double>::infinity(), max_t=0.0;
-            int iters=0;
-
 #if defined(USE_HIP)
-            char *d_send,*d_recv; hipMalloc((void**)&d_send,total_bytes); hipMalloc((void**)&d_recv,total_bytes);
-            hipMemset(d_send,'a',total_bytes); hipMemset(d_recv,0,total_bytes);
-            char *h_send=(char*)malloc(total_bytes), *h_recv=(char*)malloc(total_bytes);
-            memset(h_send,'a',total_bytes); memset(h_recv,0,total_bytes);
+                hipFree(send_buf);
+                hipFree(recv_buf);
 #elif defined(USE_CUDA)
-            int dev_count=0; cuda_check(cudaGetDeviceCount(&dev_count));
-            cuda_check(cudaSetDevice(rank % (dev_count>0?dev_count:1)));
-            char *d_send=nullptr,*d_recv=nullptr; cuda_check(cudaMalloc((void**)&d_send,total_bytes));
-            cuda_check(cudaMalloc((void**)&d_recv,total_bytes));
-            cuda_check(cudaMemset(d_send,'a',total_bytes)); cuda_check(cudaMemset(d_recv,0,total_bytes));
-            char *h_send=nullptr,*h_recv=nullptr; cuda_check(cudaMallocHost((void**)&h_send,total_bytes));
-            cuda_check(cudaMallocHost((void**)&h_recv,total_bytes));
-            memset(h_send,'a',total_bytes); memset(h_recv,0,total_bytes);
+                cuda_check(cudaFreeHost(h_send));
+                cuda_check(cudaFreeHost(h_recv));
+                cuda_check(cudaFree(d_send));
+                cuda_check(cudaFree(d_recv));
 #else
-            char *sendbuf=(char*)malloc(total_bytes), *recvbuf=(char*)malloc(total_bytes);
-            memset(sendbuf,'b',total_bytes); memset(recvbuf,0,total_bytes);
-#endif
-
-            CALI_MARK_BEGIN(warmup_region_aa);
-            for (int i=0;i<warmup;i++) {
-#if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(h_send,d_send,total_bytes,cudaMemcpyDeviceToHost));
-                MPI_Alltoall(h_send,(int)count_per_rank,MPI_CHAR,h_recv,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(d_recv,h_recv,total_bytes,cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                hipMemcpy(h_send,d_send,total_bytes,hipMemcpyDeviceToHost);
-                MPI_Alltoall(h_send,(int)count_per_rank,MPI_CHAR,h_recv,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
-                hipMemcpy(d_recv,h_recv,total_bytes,hipMemcpyHostToDevice);
-#else
-                MPI_Alltoall(sendbuf,(int)count_per_rank,MPI_CHAR,recvbuf,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
+                free(send_buf);
+                free(recv_buf);
 #endif
             }
-            CALI_MARK_END(warmup_region_aa);
+        }
 
-            CALI_MARK_BEGIN("Alltoall");
-            for (int it=0; it<PING_PONG_LIMIT; ++it) {
-                MPI_Barrier(MPI_COMM_WORLD);
-                double t0 = MPI_Wtime();
-#if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(h_send,d_send,total_bytes,cudaMemcpyDeviceToHost));
-                MPI_Alltoall(h_send,(int)count_per_rank,MPI_CHAR,h_recv,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(d_recv,h_recv,total_bytes,cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                hipMemcpy(h_send,d_send,total_bytes,hipMemcpyDeviceToHost);
-                MPI_Alltoall(h_send,(int)count_per_rank,MPI_CHAR,h_recv,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
-                hipMemcpy(d_recv,h_recv,total_bytes,hipMemcpyHostToDevice);
-#else
-                MPI_Alltoall(sendbuf,(int)count_per_rank,MPI_CHAR,recvbuf,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
-#endif
-                double dt = MPI_Wtime()-t0;
-                double mx=0; MPI_Reduce(&dt,&mx,1,MPI_DOUBLE,MPI_MAX,0,MPI_COMM_WORLD);
-                if (rank==0) {
-                    total+=mx; if (dt<min_t) min_t=dt; if (dt>max_t) max_t=dt; ++iters;
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // ===================== ALLTOALL =====================
+        if (op == OpKind::Alltoall || op == OpKind::All)
+        {
+            for (int partner_rank : partners)
+            {
+                std::string region_label = region_names[partner_rank];
+
+                size_t aa_bytes_per_rank = static_cast<size_t>(message);
+                size_t aa_total_bytes = aa_bytes_per_rank * static_cast<size_t>(size);
+
+                int warmup = 1;
+                double alltoall_total_time = 0.0;
+
+#if defined(USE_HIP)
+                char *aa_send_dev;
+                char *aa_recv_dev;
+
+                hipError_t a_err1 = hipMalloc((void**)&aa_send_dev, aa_total_bytes);
+                hipError_t a_err2 = hipMalloc((void**)&aa_recv_dev, aa_total_bytes);
+
+                if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
                 }
-            }
-            CALI_MARK_END("Alltoall");
 
-            if (rank==0) {
-                double avg = iters? total/iters:0.0;
-#if defined(USE_CALIPER)
-                cali_set_string(comm_phase_attr,"alltoall");
-                cali_set_double(aa_avg_time_sec_attr,avg);
-                cali_set_double(aa_max_time_sec_attr,max_t);
-                cali_set_double(aa_min_time_sec_attr,min_t);
+                hipError_t a_cuerr1 = hipMemset(aa_send_dev, 'a', aa_total_bytes);
+                assert(a_cuerr1 == hipSuccess);
+                hipError_t a_cuerr2 = hipMemset(aa_recv_dev, 0, aa_total_bytes);
+                assert(a_cuerr2 == hipSuccess);
+
+                char *aa_send_host = (char*) malloc(aa_total_bytes);
+                char *aa_recv_host = (char*) malloc(aa_total_bytes);
+                memset(aa_send_host, 'a', aa_total_bytes);
+                memset(aa_recv_host, 0, aa_total_bytes);
+
+#elif defined(USE_CUDA)
+                int a_dev_count = 0;
+                cuda_check(cudaGetDeviceCount(&a_dev_count));
+                cuda_check(cudaSetDevice(rank % (a_dev_count > 0 ? a_dev_count : 1)));
+
+                char *ad_send = nullptr;
+                char *ad_recv = nullptr;
+                cuda_check(cudaMalloc((void**)&ad_send, aa_total_bytes));
+                cuda_check(cudaMalloc((void**)&ad_recv, aa_total_bytes));
+                cuda_check(cudaMemset(ad_send, 'a', aa_total_bytes));
+                cuda_check(cudaMemset(ad_recv, 0, aa_total_bytes));
+
+                char *ah_send = nullptr;
+                char *ah_recv = nullptr;
+                cuda_check(cudaMallocHost((void**)&ah_send, aa_total_bytes));
+                cuda_check(cudaMallocHost((void**)&ah_recv, aa_total_bytes));
+                memset(ah_send, 'a', aa_total_bytes);
+                memset(ah_recv, 0, aa_total_bytes);
+#else
+                char *aa_send = (char*) malloc(aa_total_bytes);
+                char *aa_recv = (char*) malloc(aa_total_bytes);
+                memset(aa_send, 'b', aa_total_bytes);
+                memset(aa_recv,  0, aa_total_bytes);
 #endif
-                printf("[ALLTOALL] msg/rank=%d  avg=%.6f s  min=%.6f s  max=%.6f s\n", message, avg, min_t, max_t);
-            }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_BEGIN(warmup_region_aa);
+#endif
+
+                for (int i = 0; i < warmup; i++)
+                {
+#if defined(USE_HIP)
+                    hipMemcpy(aa_send_dev, aa_send_host, aa_total_bytes, hipMemcpyHostToDevice);
+                    hipDeviceSynchronize();
+                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+                    hipDeviceSynchronize();
+#elif defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
+                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
+#else
+                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+#endif
+                }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_END(warmup_region_aa);
+                CALI_MARK_BEGIN(region_label.c_str());
+#endif
+
+                double min_rtt = std::numeric_limits<double>::infinity();
+                double max_rtt = 0.0;
+                int iters = 0;
+
+                for (int it = 0; it < PING_PONG_LIMIT; ++it)
+                {
+                    MPI_Barrier(MPI_COMM_WORLD);
+
+                    double t0 = MPI_Wtime();
 
 #if defined(USE_HIP)
-            free(h_send); free(h_recv); hipFree(d_send); hipFree(d_recv);
+                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+                    hipDeviceSynchronize();
 #elif defined(USE_CUDA)
-            cuda_check(cudaFreeHost(h_send)); cuda_check(cudaFreeHost(h_recv));
-            cuda_check(cudaFree(d_send)); cuda_check(cudaFree(d_recv));
+                    cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
+                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
 #else
-            free(sendbuf); free(recvbuf);
+                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
 #endif
-            MPI_Barrier(MPI_COMM_WORLD);
+
+                    double t1 = MPI_Wtime();
+                    double dt = t1 - t0;
+
+                    double iter_max = 0.0;
+                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+                    if (rank == 0)
+                    {
+                        alltoall_total_time += iter_max;
+                        if(dt < min_rtt) min_rtt = dt;
+                        if(dt > max_rtt) max_rtt = dt;
+                        ++iters;
+
+                        double avg_rtt = (iters > 0) ? (alltoall_total_time / iters) : 0.0;
+#if defined(USE_CALIPER)
+                        cali_set_string(comm_phase_attr, "alltoall");
+                        cali_set_double(aa_avg_time_sec_attr, avg_rtt);
+                        cali_set_double(aa_max_time_sec_attr, max_rtt);
+                        cali_set_double(aa_min_time_sec_attr, min_rtt);
+#endif
+                    }
+                }
+#if defined(USE_CALIPER)
+                CALI_MARK_END(region_label.c_str());
+#endif
+
+#if defined(USE_HIP)
+                free(aa_send_host);
+                free(aa_recv_host);
+                hipFree(aa_send_dev);
+                hipFree(aa_recv_dev);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFreeHost(ah_send));
+                cuda_check(cudaFreeHost(ah_recv));
+                cuda_check(cudaFree(ad_send));
+                cuda_check(cudaFree(ad_recv));
+#else
+                free(aa_send);
+                free(aa_recv);
+#endif
+            }
         }
 
-        // ---------------- REDUCE (selected) ----------------
-        if (op == OpKind::Reduce) {
-            size_t count = (size_t)message;
-            if (count > INT_MAX) { if(rank==0) fprintf(stderr,"Reduce count too large\n"); MPI_Abort(MPI_COMM_WORLD,3); }
-            int warmup=1; double total=0, min_t=std::numeric_limits<double>::infinity(), max_t=0; int iters=0;
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // ===================== REDUCE =====================
+        if (op == OpKind::Reduce || op == OpKind::All)
+        {
+            for (int partner_rank : partners)
+            {
+                std::string region_label = region_names[partner_rank];
+
+                size_t red_count = static_cast<size_t>(message);
+                if (red_count > INT_MAX) {
+                    if (rank == 0) fprintf(stderr, "Reduce count too large\n");
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                int warmup = 1;
+                double red_total_time = 0.0;
 
 #if defined(USE_CUDA)
-            char *d_send=nullptr,*d_recv=nullptr; cuda_check(cudaMalloc((void**)&d_send,count)); cuda_check(cudaMalloc((void**)&d_recv,count));
-            cuda_check(cudaMemset(d_send,'r',count)); cuda_check(cudaMemset(d_recv,0,count));
-            char *h_send=nullptr,*h_recv=nullptr; cuda_check(cudaMallocHost((void**)&h_send,count)); cuda_check(cudaMallocHost((void**)&h_recv,count));
-            memset(h_send,'r',count); memset(h_recv,0,count);
+                char *rd_d_send=nullptr;
+                char *rd_d_recv=nullptr;
+
+                cuda_check(cudaMalloc((void**)&rd_d_send, red_count));
+                cuda_check(cudaMalloc((void**)&rd_d_recv, red_count));
+                cuda_check(cudaMemset(rd_d_send, 'r', red_count));
+                cuda_check(cudaMemset(rd_d_recv, 0,   red_count));
+
+                char *rd_h_send=nullptr;
+                char *rd_h_recv=nullptr;
+                cuda_check(cudaMallocHost((void**)&rd_h_send, red_count));
+                cuda_check(cudaMallocHost((void**)&rd_h_recv, red_count));
+                memset(rd_h_send, 'r', red_count);
+                memset(rd_h_recv, 0,   red_count);
 #elif defined(USE_HIP)
-            char *d_send=nullptr,*d_recv=nullptr; hipMalloc((void**)&d_send,count); hipMalloc((void**)&d_recv,count);
-            hipMemset(d_send,'r',count); hipMemset(d_recv,0,count);
-            char *h_send=(char*)malloc(count), *h_recv=(char*)malloc(count);
-            memset(h_send,'r',count); memset(h_recv,0,count);
+                char *rd_d_send=nullptr;
+                char *rd_d_recv=nullptr;
+
+                hipError_t a_err1 = hipMalloc((void**)&rd_d_send, red_count);
+                hipError_t a_err2 = hipMalloc((void**)&rd_d_recv, red_count);
+
+                if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                hipError_t a_cuerr1 = hipMemset(rd_d_send, 'a', red_count);
+                assert(a_cuerr1 == hipSuccess);
+                hipError_t a_cuerr2 = hipMemset(rd_d_recv, 0, red_count);
+                assert(a_cuerr2 == hipSuccess);
+
+                char *rd_h_send = (char*)malloc(red_count);
+                char *rd_h_recv = (char*)malloc(red_count);
+                memset(rd_h_send, 'r', red_count);
+                memset(rd_h_recv, 0,   red_count);
 #else
-            char *sendbuf=(char*)malloc(count), *recvbuf=(char*)malloc(count);
-            memset(sendbuf,'r',count); memset(recvbuf,0,count);
+                char *rd_send = (char*)malloc(red_count);
+                char *rd_recv = (char*)malloc(red_count);
+                memset(rd_send, 'r', red_count);
+                memset(rd_recv, 0,   red_count);
 #endif
 
-            CALI_MARK_BEGIN(warmup_region_red);
-            for (int i=0;i<warmup;i++) {
-#if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(h_send,d_send,count,cudaMemcpyDeviceToHost));
-                MPI_Reduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(d_recv,h_recv,count,cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                hipMemcpy(h_send,d_send,count,hipMemcpyDeviceToHost);
-                MPI_Reduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
-                hipMemcpy(d_recv,h_recv,count,hipMemcpyHostToDevice);
-#else
-                MPI_Reduce(sendbuf,recvbuf,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
-#endif
-            }
-            CALI_MARK_END(warmup_region_red);
-
-            CALI_MARK_BEGIN("Reduce");
-            for (int i=0;i<PING_PONG_LIMIT;i++) {
-                MPI_Barrier(MPI_COMM_WORLD);
-                double t0 = MPI_Wtime();
-#if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(h_send,d_send,count,cudaMemcpyDeviceToHost));
-                MPI_Reduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(d_recv,h_recv,count,cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                hipMemcpy(h_send,d_send,count,hipMemcpyDeviceToHost);
-                MPI_Reduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
-                hipMemcpy(d_recv,h_recv,count,hipMemcpyHostToDevice);
-#else
-                MPI_Reduce(sendbuf,recvbuf,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
-#endif
-                double dt = MPI_Wtime()-t0;
-                double mx=0; MPI_Reduce(&dt,&mx,1,MPI_DOUBLE,MPI_MAX,0,MPI_COMM_WORLD);
-                if (rank==0) { total+=mx; if (dt<min_t) min_t=dt; if (dt>max_t) max_t=dt; ++iters; }
-            }
-            CALI_MARK_END("Reduce");
-
-            if (rank==0) {
-                double avg = iters? total/iters:0.0;
 #if defined(USE_CALIPER)
-                cali_set_string(comm_phase_attr,"reduce");
-                cali_set_double(red_avg_time_sec_attr,avg);
-                cali_set_double(red_max_time_sec_attr,max_t);
-                cali_set_double(red_min_time_sec_attr,min_t);
+                CALI_MARK_BEGIN(warmup_region_red);
 #endif
-                printf("[REDUCE] msg=%d  avg=%.6f s  min=%.6f s  max=%.6f s\n", message, avg, min_t, max_t);
-            }
-
+                for (int i = 0; i < warmup; i++)
+                {
 #if defined(USE_CUDA)
-            cuda_check(cudaFreeHost(h_send)); cuda_check(cudaFreeHost(h_recv));
-            cuda_check(cudaFree(d_send)); cuda_check(cudaFree(d_recv));
+                    cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-            free(h_send); free(h_recv); hipFree(d_send); hipFree(d_recv);
+                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
 #else
-            free(sendbuf); free(recvbuf);
+                    MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
 #endif
-            MPI_Barrier(MPI_COMM_WORLD);
+                }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_END(warmup_region_red);
+                CALI_MARK_BEGIN(region_label.c_str());
+#endif
+
+                double min_rtt = std::numeric_limits<double>::infinity();
+                double max_rtt = 0.0;
+                int iters = 0;
+
+                for(int i = 0; i < PING_PONG_LIMIT; i++)
+                {
+                    MPI_Barrier(MPI_COMM_WORLD);
+                    double t0 = MPI_Wtime();
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+#endif
+                    double dt = MPI_Wtime() - t0;
+                    double iter_max = 0.0;
+                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+
+                    if(rank == 0)
+                    {
+                        red_total_time += iter_max;
+                        if(dt < min_rtt) min_rtt = dt;
+                        if(dt > max_rtt) max_rtt = dt;
+                        ++iters;
+
+                        double avg_rtt = (iters > 0) ? (red_total_time / iters) : 0.0;
+#if defined(USE_CALIPER)
+                        cali_set_string(comm_phase_attr, "reduce");
+                        cali_set_double(red_avg_time_sec_attr, avg_rtt);
+                        cali_set_double(red_max_time_sec_attr, max_rtt);
+                        cali_set_double(red_min_time_sec_attr, min_rtt);
+#endif
+                    }
+                }
+#if defined(USE_CALIPER)
+                CALI_MARK_END(region_label.c_str());
+#endif
+
+#if defined(USE_HIP)
+                free(rd_h_send);
+                free(rd_h_recv);
+                hipFree(rd_d_send);
+                hipFree(rd_d_recv);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFreeHost(rd_h_send));
+                cuda_check(cudaFreeHost(rd_h_recv));
+                cuda_check(cudaFree(rd_d_send));
+                cuda_check(cudaFree(rd_d_recv));
+#else
+                free(rd_send);
+                free(rd_recv);
+#endif
+            }
         }
 
-        // ---------------- ALLREDUCE (selected) ----------------
-        if (op == OpKind::Allreduce) {
-            size_t count = (size_t)message;
-            if (count > INT_MAX) { if(rank==0) fprintf(stderr,"Allreduce count too large\n"); MPI_Abort(MPI_COMM_WORLD,4); }
-            int warmup=1; double total=0, min_t=std::numeric_limits<double>::infinity(), max_t=0; int iters=0;
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // ===================== ALLREDUCE =====================
+        if (op == OpKind::Allreduce || op == OpKind::All)
+        {
+            for (int partner_rank : partners)
+            {
+                std::string region_label = region_names[partner_rank];
+
+                size_t ar_count = static_cast<size_t>(message);
+                if (ar_count > INT_MAX) {
+                    if (rank == 0) fprintf(stderr, "Allreduce count too large\n");
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+                int warmup = 1;
+                double ar_total_time = 0.0;
 
 #if defined(USE_CUDA)
-            char *d_send=nullptr,*d_recv=nullptr; cuda_check(cudaMalloc((void**)&d_send,count)); cuda_check(cudaMalloc((void**)&d_recv,count));
-            cuda_check(cudaMemset(d_send,'a',count)); cuda_check(cudaMemset(d_recv,0,count));
-            char *h_send=nullptr,*h_recv=nullptr; cuda_check(cudaMallocHost((void**)&h_send,count)); cuda_check(cudaMallocHost((void**)&h_recv,count));
-            memset(h_send,'a',count); memset(h_recv,0,count);
+                char *ar_d_send=nullptr;
+                char *ar_d_recv=nullptr;
+                cuda_check(cudaMalloc((void**)&ar_d_send, ar_count));
+                cuda_check(cudaMalloc((void**)&ar_d_recv, ar_count));
+                cuda_check(cudaMemset(ar_d_send, 'a', ar_count));
+                cuda_check(cudaMemset(ar_d_recv, 0,   ar_count));
+
+                char *ar_h_send=nullptr;
+                char *ar_h_recv=nullptr;
+                cuda_check(cudaMallocHost((void**)&ar_h_send, ar_count));
+                cuda_check(cudaMallocHost((void**)&ar_h_recv, ar_count));
+                memset(ar_h_send, 'a', ar_count);
+                memset(ar_h_recv, 0,   ar_count);
 #elif defined(USE_HIP)
-            char *d_send=nullptr,*d_recv=nullptr; hipMalloc((void**)&d_send,count); hipMalloc((void**)&d_recv,count);
-            hipMemset(d_send,'a',count); hipMemset(d_recv,0,count);
-            char *h_send=(char*)malloc(count), *h_recv=(char*)malloc(count);
-            memset(h_send,'a',count); memset(h_recv,0,count);
+                char *ar_d_send=nullptr;
+                char *ar_d_recv=nullptr;
+
+                hipError_t a_err1 = hipMalloc((void**)&ar_d_send, ar_count);
+                hipError_t a_err2 = hipMalloc((void**)&ar_d_recv, ar_count);
+
+                if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                hipError_t a_cuerr1 = hipMemset(ar_d_send, 'a', ar_count);
+                assert(a_cuerr1 == hipSuccess);
+                hipError_t a_cuerr2 = hipMemset(ar_d_recv, 0, ar_count);
+                assert(a_cuerr2 == hipSuccess);
+
+                char *ar_h_send = (char*)malloc(ar_count);
+                char *ar_h_recv = (char*)malloc(ar_count);
+                memset(ar_h_send, 'a', ar_count);
+                memset(ar_h_recv, 0,   ar_count);
 #else
-            char *sendbuf=(char*)malloc(count), *recvbuf=(char*)malloc(count);
-            memset(sendbuf,'a',count); memset(recvbuf,0,count);
+                char *ar_send = (char*)malloc(ar_count);
+                char *ar_recv = (char*)malloc(ar_count);
+                memset(ar_send, 'a', ar_count);
+                memset(ar_recv, 0,   ar_count);
 #endif
 
-            CALI_MARK_BEGIN(warmup_region_ar);
-            for (int i=0;i<warmup;i++) {
-#if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(h_send,d_send,count,cudaMemcpyDeviceToHost));
-                MPI_Allreduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(d_recv,h_recv,count,cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                hipMemcpy(h_send,d_send,count,hipMemcpyDeviceToHost);
-                MPI_Allreduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
-                hipMemcpy(d_recv,h_recv,count,hipMemcpyHostToDevice);
-#else
-                MPI_Allreduce(sendbuf,recvbuf,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
-#endif
-            }
-            CALI_MARK_END(warmup_region_ar);
-
-            CALI_MARK_BEGIN("Allreduce");
-            for (int i=0;i<PING_PONG_LIMIT;i++) {
-                MPI_Barrier(MPI_COMM_WORLD);
-                double t0 = MPI_Wtime();
-#if defined(USE_CUDA)
-                cuda_check(cudaMemcpy(h_send,d_send,count,cudaMemcpyDeviceToHost));
-                MPI_Allreduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
-                cuda_check(cudaMemcpy(d_recv,h_recv,count,cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                hipMemcpy(h_send,d_send,count,hipMemcpyDeviceToHost);
-                MPI_Allreduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
-                hipMemcpy(d_recv,h_recv,count,hipMemcpyHostToDevice);
-#else
-                MPI_Allreduce(sendbuf,recvbuf,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
-#endif
-                double dt = MPI_Wtime()-t0;
-                double mx=0; MPI_Allreduce(&dt,&mx,1,MPI_DOUBLE,MPI_MAX,MPI_COMM_WORLD);
-                if (rank==0) { total+=mx; if (dt<min_t) min_t=dt; if (dt>max_t) max_t=dt; ++iters; }
-            }
-            CALI_MARK_END("Allreduce");
-
-            if (rank==0) {
-                double avg = iters? total/iters:0.0;
 #if defined(USE_CALIPER)
-                cali_set_string(comm_phase_attr,"allreduce");
-                cali_set_double(ar_avg_time_sec_attr,avg);
-                cali_set_double(ar_max_time_sec_attr,max_t);
-                cali_set_double(ar_min_time_sec_attr,min_t);
+                CALI_MARK_BEGIN(warmup_region_ar);
 #endif
-                printf("[ALLREDUCE] msg=%d  avg=%.6f s  min=%.6f s  max=%.6f s\n", message, avg, min_t, max_t);
-            }
-
+                for (int i = 0; i < warmup; i++)
+                {
 #if defined(USE_CUDA)
-            cuda_check(cudaFreeHost(h_send)); cuda_check(cudaFreeHost(h_recv));
-            cuda_check(cudaFree(d_send)); cuda_check(cudaFree(d_recv));
+                    cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-            free(h_send); free(h_recv); hipFree(d_send); hipFree(d_recv);
+                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
 #else
-            free(sendbuf); free(recvbuf);
+                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
 #endif
-            MPI_Barrier(MPI_COMM_WORLD);
+                }
+#if defined(USE_CALIPER)
+                CALI_MARK_END(warmup_region_ar);
+                CALI_MARK_BEGIN(region_label.c_str());
+#endif
+                double min_rtt = std::numeric_limits<double>::infinity();
+                double max_rtt = 0.0;
+                int iters = 0;
+
+                for(int i = 0; i < PING_PONG_LIMIT; i++)
+                {
+                    MPI_Barrier(MPI_COMM_WORLD);
+                    double t0 = MPI_Wtime();
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+#endif
+                    double dt = MPI_Wtime() - t0;
+                    double iter_max = 0.0;
+                    MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
+                    if(rank == 0)
+                    {
+                        ar_total_time += iter_max;
+                        if(dt < min_rtt) min_rtt = dt;
+                        if(dt > max_rtt) max_rtt = dt;
+                        ++iters;
+
+                        double avg_rtt = (iters > 0) ? (ar_total_time / iters) : 0.0;
+#if defined(USE_CALIPER)
+                        cali_set_string(comm_phase_attr, "allreduce");
+                        cali_set_double(ar_avg_time_sec_attr, avg_rtt);
+                        cali_set_double(ar_max_time_sec_attr, max_rtt);
+                        cali_set_double(ar_min_time_sec_attr, min_rtt);
+#endif
+                    }
+                }
+#if defined(USE_CALIPER)
+                CALI_MARK_END(region_label.c_str());
+#endif
+
+#if defined(USE_HIP)
+                free(ar_h_send);
+                free(ar_h_recv);
+                hipFree(ar_d_send);
+                hipFree(ar_d_recv);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFreeHost(ar_h_send));
+                cuda_check(cudaFreeHost(ar_h_recv));
+                cuda_check(cudaFree(ar_d_send));
+                cuda_check(cudaFree(ar_d_recv));
+#else
+                free(ar_send);
+                free(ar_recv);
+#endif
+            }
         }
 
 #if defined(USE_CALIPER)
         mgr[message].stop();
 #endif
-    } // message sweep
+    }
 
 #if defined(USE_CALIPER)
-    if (rank == 0 && !all_comm_pairs.empty()) {
+    if (rank == 0 && !all_comm_pairs.empty())
+    {
         adiak::value("all_comm_pairs", all_comm_pairs);
     }
-    for (auto &m : mgr) m.second.flush();
+    for (auto &m : mgr)
+    {
+        m.second.flush();
+    }
 #endif
 
     MPI_Finalize();

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -136,9 +136,6 @@ build_pingpong_pairs(const std::string& region_label,
         int rps = sys_cores_per_socket;
         int delta = rps;
 
-        if (2 * delta > size)
-            return pairs; // not enough ranks
-
         int s0 = 0;
         int s1 = delta / 8;
         int s2 = delta / 4;
@@ -489,12 +486,13 @@ int main(int argc, char **argv)
                     continue;
                 }
 
-
+                printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
+                           region_label.c_str(), pairs.size(), partner_rank);
 
                 if (rank == 0)
                 {
-                    printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
-                           region_label.c_str(), pairs.size(), partner_rank);
+                    // printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
+                    //        region_label.c_str(), pairs.size(), partner_rank);
                     for (auto &p : pairs) {
                         printf("  pair %d (%s) <-> %d (%s)\n",
                                p.src, all_hostnames[p.src],
@@ -746,6 +744,7 @@ int main(int argc, char **argv)
                 free(recv_flat);
 #endif
             } // end for (partner_rank : partners)
+            printf("Done with Pingpong");
         }     // end if (PingPong || All)
 
         MPI_Barrier(MPI_COMM_WORLD);

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -559,7 +559,7 @@ int main(int argc, char **argv)
                 memset(h_recv, 0, message);
 
                 cuda_check(cudaMemcpy(d_send, h_send, message, cudaMemcpyHostToDevice));
-                cuda_check(cudaMemset(d_recv, 0, message);
+                cuda_check(cudaMemset(d_recv, 0, message));
 
 #else
                 char *send_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
@@ -585,7 +585,7 @@ int main(int argc, char **argv)
 #endif
                 for (int i = 0; i < warmup; i++)
                 {
-#if defined(USE_HIP)er
+#if defined(USE_HIP)
                     if (rank < partner) {
                         MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                         MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -559,16 +559,12 @@ int main(int argc, char **argv)
 #else
                 const int iters_total = PING_PONG_LIMIT;
 
-                char* send_flat = (char*)malloc((size_t)iters_total * (size_t)message);
-                char* recv_flat = (char*)malloc((size_t)iters_total * (size_t)message);
+                std::vector<std::vector<char>> send_mat(iters_total, std::vector<char>(message));
+                std::vector<std::vector<char>> recv_mat(iters_total, std::vector<char>(message));
 
-                std::vector<char*> send_rows(iters_total);
-                std::vector<char*> recv_rows(iters_total);
                 for (int it = 0; it < iters_total; ++it) {
-                    send_rows[it] = send_flat + (size_t)it * (size_t)message;
-                    recv_rows[it] = recv_flat + (size_t)it * (size_t)message;
-                    fill_with_random_pattern(send_rows[it], (size_t)message);
-                    memset(recv_rows[it], 0, (size_t)message);
+                    fill_with_random_pattern(send_mat[it].data(), (size_t)message);
+                    memset(recv_mat[it].data(), 0, (size_t)message);
                 }
 #endif
 
@@ -604,8 +600,8 @@ int main(int argc, char **argv)
                     }
 #else
                     int it = i % iters_total;
-                    char* srow = send_rows[it];
-                    char* rrow = recv_rows[it];
+                    char* srow = send_mat[it].data();
+                    char* rrow = recv_mat[it].data();
 
                     if (rank < partner) {
                         MPI_Send(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
@@ -664,8 +660,8 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
-                    char* srow = send_rows[i];
-                    char* rrow = recv_rows[i];
+                    char* srow = send_mat[i].data();
+                    char* rrow = recv_mat[i].data();
 
                     if (rank < partner) {
                         MPI_Isend(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
@@ -719,8 +715,8 @@ int main(int argc, char **argv)
                 cuda_check(cudaFree(d_send));
                 cuda_check(cudaFree(d_recv));
 #else
-                free(send_flat);
-                free(recv_flat);
+                // free(send_flat);
+                // free(recv_flat);
 #endif
             } // end for (partner_rank : partners)
         }     // end if (PingPong || All)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -295,6 +295,7 @@ int main(int argc, char **argv)
         rankmap << "}";
         adiak::value("rank_node_map", rankmap.str());
         adiak::value("iterations", PING_PONG_LIMIT);
+        adiak::value("pingpong_num_pairs", pingpong_num_pairs);
 #endif
     }
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -618,12 +618,12 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
-                    printf("before MPI_Barrier before inside warmup %d\n", i);
+                    printf("rank: %d before MPI_Barrier before inside warmup %d\n", rank, i);
                     MPI_Barrier(MPI_COMM_WORLD);
-                    printf("after MPI_Barrier before waitall inside warmup %d\n", i);
+                    printf("rank: %d after MPI_Barrier before waitall inside warmup %d\n", rank, i);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    printf("After Waitall warmup %d\n", i);
+                    printf("rank: %d After Waitall warmup %d\n", rank, i);
 #endif
                 }
                 printf("before MPI_Barrier outside warmup\n");
@@ -684,12 +684,12 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
-                    printf("before MPI_Barrier inside iteration %d\n", i);
+                    printf("rank: %d before MPI_Barrier inside iteration %d\n", rank, i);
                     MPI_Barrier(MPI_COMM_WORLD);
-                    printf("after MPI_barrier before waitall inside iteration %d\n", i);
+                    printf("rank: %d after MPI_barrier before waitall inside iteration %d\n", rank, i);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    printf("After MPI_Waitall %d\n", i);
+                    printf("rank: %d After MPI_Waitall %d\n", rank, i);
 #endif
 
                     if (i_am_timing_rank) {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -885,8 +885,8 @@ int main(int argc, char **argv)
                     if (rank == 0)
                     {
                         alltoall_total_time += iter_max;
-                        if(dt < min_rtt) min_rtt = dt;      //min & max not computing correctly on rank 0
-                        if(dt > max_rtt) max_rtt = dt;
+                        if(iter_max < min_rtt) min_rtt = iter_max;      //min & max not computing correctly on rank 0
+                        if(iter_max > max_rtt) max_rtt = iter_max;
                         ++iters;
 
                         double avg_rtt = (iters > 0) ? (alltoall_total_time / iters) : 0.0;
@@ -1047,8 +1047,8 @@ int main(int argc, char **argv)
                     if(rank == 0)
                     {
                         red_total_time += iter_max;
-                        if(dt < min_rtt) min_rtt = dt;      //fix min and max calculation
-                        if(dt > max_rtt) max_rtt = dt;
+                        if(iter_max < min_rtt) min_rtt = iter_max;      //fix min and max calculation
+                        if(iter_max > max_rtt) max_rtt = iter_max;
                         ++iters;
 
                         double avg_rtt = (iters > 0) ? (red_total_time / iters) : 0.0;
@@ -1202,8 +1202,8 @@ int main(int argc, char **argv)
                     if(rank == 0)
                     {
                         ar_total_time += iter_max;
-                        if(dt < min_rtt) min_rtt = dt;          //fix min and max calculation
-                        if(dt > max_rtt) max_rtt = dt;
+                        if(iter_max < min_rtt) min_rtt = iter_max;          //fix min and max calculation
+                        if(iter_max > max_rtt) max_rtt = iter_max;
                         ++iters;
 
                         double avg_rtt = (iters > 0) ? (ar_total_time / iters) : 0.0;

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -190,9 +190,9 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
     std::vector<std::string> all_comm_pairs;
     static std::map<int, cali::ConfigManager> mgr;
-    //MPI_Comm adiak_comm = MPI_COMM_WORLD;
-    //adiak::init(&adiak_comm);
-    //adiak::collect_all();
+    MPI_Comm adiak_comm = MPI_COMM_WORLD;
+    adiak::init(&adiak_comm);
+    adiak::collect_all();
     CALI_CXX_MARK_FUNCTION;
 #endif
 
@@ -298,9 +298,9 @@ int main(int argc, char **argv)
                 rankmap << ", ";
         }
         rankmap << "}";
-        //adiak::value("rank_node_map", rankmap.str());
-        //adiak::value("iterations", num_iterations);
-        //adiak::value("pingpong_num_pairs", pingpong_num_pairs);
+        adiak::value("rank_node_map", rankmap.str());
+        adiak::value("iterations", num_iterations);
+        adiak::value("pingpong_num_pairs", pingpong_num_pairs);
 #endif
     }
 
@@ -452,7 +452,7 @@ int main(int argc, char **argv)
 
         mgr[message].add_option_spec(src_dest_attributes);
         mgr[message].set_default_parameter("pingpong_attributes", "true");
-        //adiak::value("message_size", message);
+        adiak::value("message_size", message);
         mgr[message].add(profile.c_str());
         mgr[message].start();
 #endif
@@ -1250,7 +1250,7 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
     if (rank == 0 && !all_comm_pairs.empty())
     {
-        //adiak::value("all_comm_pairs", all_comm_pairs);
+        adiak::value("all_comm_pairs", all_comm_pairs);
     }
     for (auto &m : mgr)
     {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -908,7 +908,6 @@ int main(int argc, char **argv)
                 free(aa_send);
                 free(aa_recv);
 #endif
-                sleep(1);
             }
         }
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -44,6 +44,12 @@ inline void cuda_check(cudaError_t e) {
 }
 #endif
 
+// If your MPI is GPU-aware (can send/recv device pointers), set this to 1 at compile time:
+//   -DASSUME_GPU_AWARE_MPI=1
+#ifndef ASSUME_GPU_AWARE_MPI
+#define ASSUME_GPU_AWARE_MPI 0
+#endif
+
 // ---- Operation selector (default: PingPong) ----
 enum class OpKind { All, PingPong, Alltoall, Reduce, Allreduce };
 
@@ -171,6 +177,43 @@ build_pingpong_pairs(const std::string& region_label,
     return pairs;
 }
 
+// ---------- Unified 2D payload helpers ----------
+static inline size_t row_index(int iter, int j, int window_size) {
+    return (size_t)iter * (size_t)window_size + (size_t)j;
+}
+static inline char* row_ptr(char* base, size_t bytes_per_row, size_t row) {
+    return base + row * bytes_per_row;
+}
+static inline const char* row_ptr(const char* base, size_t bytes_per_row, size_t row) {
+    return base + row * bytes_per_row;
+}
+
+// Pinned host alloc when CUDA/HIP enabled; malloc otherwise.
+// This is ONLY for host-side canonical 2D data + optional staging.
+static inline void* host_alloc(size_t bytes) {
+#if defined(USE_CUDA)
+    void* p = nullptr;
+    cuda_check(cudaMallocHost(&p, bytes));
+    return p;
+#elif defined(USE_HIP)
+    void* p = nullptr;
+    hipError_t e = hipHostMalloc(&p, bytes);
+    if (e != hipSuccess) return nullptr;
+    return p;
+#else
+    return std::malloc(bytes);
+#endif
+}
+
+static inline void host_free(void* p) {
+#if defined(USE_CUDA)
+    cuda_check(cudaFreeHost(p));
+#elif defined(USE_HIP)
+    hipHostFree(p);
+#else
+    std::free(p);
+#endif
+}
 
 int main(int argc, char **argv)
 {
@@ -196,7 +239,7 @@ int main(int argc, char **argv)
 #endif
 
     int PING_PONG_LIMIT = 10;
-    const int WINDOW_SIZE = 64;
+    const int WINDOW_SIZE = 1;
     int msg_size = 1;
     int n_nodes = 1;
     int sys_cores_per_socket = 1;
@@ -508,122 +551,144 @@ int main(int argc, char **argv)
 #endif
                 }
 
-                double total_time = 0.0;
-                int warmup = 1;
+                // ------------------------------------------------------------
+                // Canonical pre-filled 2D payload (OUTSIDE MPI/CUDA/HIP branches)
+                // rows = PING_PONG_LIMIT * WINDOW_SIZE
+                // row(i,j) holds unique data
+                // ------------------------------------------------------------
+                const int ITERS = PING_PONG_LIMIT;
+                const int W     = WINDOW_SIZE;
+                const size_t bytes_per_row = (size_t)message;
+                const size_t total_rows    = (size_t)ITERS * (size_t)W;
 
-                // ---------- buffer allocation ----------
-#if defined(USE_HIP)
-                char *send_buf;
-                char *recv_buf;
+                const size_t send2d_bytes      = total_rows * bytes_per_row;
+                const size_t recv_window_bytes = (size_t)W * bytes_per_row;
 
-                hipError_t err1 = hipMalloc((void**)&send_buf, message);
-                hipError_t err2 = hipMalloc((void**)&recv_buf, message);
-
-                if (err1 != hipSuccess || err2 != hipSuccess) {
-                    fprintf(stderr, "HIP malloc failed: %s %s\n",
-                            hipGetErrorString(err1),
-                            hipGetErrorString(err2));
+                char* host_send_2d  = (char*)host_alloc(send2d_bytes);
+                char* host_recv_win = (char*)host_alloc(recv_window_bytes);
+                if (!host_send_2d || !host_recv_win) {
+                    if (rank == 0) fprintf(stderr, "host_alloc failed\n");
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
 
-                {
-                    char* h_rand = (char*)malloc(message);
-                    fill_with_random_pattern(h_rand, (size_t)message);
-                    hipError_t cuerr1 =
-                        hipMemcpy(send_buf, h_rand, message, hipMemcpyHostToDevice);
-                    assert(cuerr1 == hipSuccess);
-                    free(h_rand);
+                // Fill ONCE: each (iter,window_slot) has different content
+                for (size_t r = 0; r < total_rows; ++r) {
+                    fill_with_random_pattern(row_ptr(host_send_2d, bytes_per_row, r), bytes_per_row);
                 }
-                hipError_t cuerr2 = hipMemset(recv_buf, 0, message);
-                assert(cuerr2 == hipSuccess);
+                memset(host_recv_win, 0, recv_window_bytes);
 
+                // Requests (CPU-side handle arrays) always exist
+                std::vector<MPI_Request> sreqs(W, MPI_REQUEST_NULL);
+                std::vector<MPI_Request> rreqs(W, MPI_REQUEST_NULL);
+
+                // ------------------------------------------------------------
+                // Backend buffers (only for CUDA/HIP; MPI-only uses host directly)
+                // We still DO NOT generate/refill inside timed loop—just index.
+                // ------------------------------------------------------------
+#if defined(USE_HIP)
+                // Optionally keep a full device copy of the 2D send payload:
+                char* d_send_2d = nullptr;
+                char* d_recv_win = nullptr;
+                hipError_t e1 = hipMalloc((void**)&d_send_2d, send2d_bytes);
+                hipError_t e2 = hipMalloc((void**)&d_recv_win, recv_window_bytes);
+                if (e1 != hipSuccess || e2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n",
+                            hipGetErrorString(e1), hipGetErrorString(e2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+                hipError_t e3 = hipMemcpy(d_send_2d, host_send_2d, send2d_bytes, hipMemcpyHostToDevice);
+                hipError_t e4 = hipMemset(d_recv_win, 0, recv_window_bytes);
+                if (e3 != hipSuccess || e4 != hipSuccess) {
+                    fprintf(stderr, "HIP memcpy/memset failed: %s %s\n",
+                            hipGetErrorString(e3), hipGetErrorString(e4));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                // If NOT GPU-aware MPI, we will stage through host buffers (already pinned via host_alloc)
+                // using host_send_2d row pointers directly.
 #elif defined(USE_CUDA)
                 int dev_count = 0;
                 cuda_check(cudaGetDeviceCount(&dev_count));
                 cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
 
-                char *d_send = nullptr;
-                char *d_recv = nullptr;
-                cuda_check(cudaMalloc((void**)&d_send, message));
-                cuda_check(cudaMalloc((void**)&d_recv, message));
-
-                char *h_send = nullptr, *h_recv = nullptr;
-                cuda_check(cudaMallocHost((void**)&h_send, message));
-                cuda_check(cudaMallocHost((void**)&h_recv, message));
-
-                fill_with_random_pattern(h_send, (size_t)message);
-                memset(h_recv, 0, message);
-
-                cuda_check(cudaMemcpy(d_send, h_send, message, cudaMemcpyHostToDevice));
-                cuda_check(cudaMemset(d_recv, 0, message));
-
-#else
-                char* send_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
-                char* recv_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
-
-                std::vector<char*> send_rows(WINDOW_SIZE);
-                std::vector<char*> recv_rows(WINDOW_SIZE);
-
-                for (int j = 0; j < WINDOW_SIZE; ++j) {
-                    send_rows[j] = send_flat + (size_t)j * (size_t)message;
-                    recv_rows[j] = recv_flat + (size_t)j * (size_t)message;
-                    fill_with_random_pattern(send_rows[j], (size_t)message);
-                    memset(recv_rows[j], 0, (size_t)message);
-                }
-
-                std::vector<MPI_Request> sreqs(WINDOW_SIZE);
-                std::vector<MPI_Request> rreqs(WINDOW_SIZE);
-
+                char* d_send_2d = nullptr;
+                char* d_recv_win = nullptr;
+                cuda_check(cudaMalloc((void**)&d_send_2d, send2d_bytes));
+                cuda_check(cudaMalloc((void**)&d_recv_win, recv_window_bytes));
+                cuda_check(cudaMemcpy(d_send_2d, host_send_2d, send2d_bytes, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(d_recv_win, 0, recv_window_bytes));
 #endif
+
+                double total_time = 0.0;
+                const int warmup = 1;
+                const int tag_base = 1000;
 
                 // ---------- warmup ----------
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region);
 #endif
-                const int tag_base = 1000;
-                for (int i = 0; i < warmup; i++)
+                for (int w = 0; w < warmup; ++w)
                 {
-#if defined(USE_HIP)
+                    const int warm_iter = 0; // warmup always uses row set for iter 0
+
+#if defined(USE_HIP) || defined(USE_CUDA)
+#if ASSUME_GPU_AWARE_MPI
+                    // GPU-aware: send/recv directly using device pointers into the device 2D buffer
                     if (rank < partner) {
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
+                        for (int j = 0; j < W; ++j) {
+                            size_t r = row_index(warm_iter, j, W);
+                            char* d_src = d_send_2d + r * bytes_per_row;
+                            char* d_dst = d_recv_win + (size_t)j * bytes_per_row;
+                            MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
+                            MPI_Recv(d_dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        }
                     } else {
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                    }
-#elif defined(USE_CUDA)
-                    if (rank < partner) {
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                    } else {
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        for (int j = 0; j < W; ++j) {
+                            size_t r = row_index(warm_iter, j, W);
+                            char* d_src = d_send_2d + r * bytes_per_row;
+                            char* d_dst = d_recv_win + (size_t)j * bytes_per_row;
+                            MPI_Recv(d_dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
+                        }
                     }
 #else
-                    for (int j = 0; j < WINDOW_SIZE; ++j){
-                        fill_with_random_pattern(send_rows[j], (size_t)message);
-                    }                    
-
-                    for (int j = 0; j < WINDOW_SIZE; ++j) {
-                        MPI_Irecv(recv_rows[j], message, MPI_CHAR, partner,
-                                tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
+                    // Not GPU-aware: use canonical host 2D rows directly for MPI; optionally move recv into device window
+                    if (rank < partner) {
+                        for (int j = 0; j < W; ++j) {
+                            size_t r = row_index(warm_iter, j, W);
+                            const char* src = row_ptr(host_send_2d, bytes_per_row, r);
+                            char* dst = host_recv_win + (size_t)j * bytes_per_row;
+                            MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
+                            MPI_Recv(dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        }
+                    } else {
+                        for (int j = 0; j < W; ++j) {
+                            size_t r = row_index(warm_iter, j, W);
+                            const char* src = row_ptr(host_send_2d, bytes_per_row, r);
+                            char* dst = host_recv_win + (size_t)j * bytes_per_row;
+                            MPI_Recv(dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
+                        }
                     }
 
-                    for (int j = 0; j < WINDOW_SIZE; ++j) {
-                        MPI_Isend(send_rows[j], message, MPI_CHAR, partner,
-                                tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                    // Mirror recv window into device (optional, preserves your old “device recv” behavior)
+#if defined(USE_HIP)
+                    hipMemcpy(d_recv_win, host_recv_win, recv_window_bytes, hipMemcpyHostToDevice);
+#elif defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(d_recv_win, host_recv_win, recv_window_bytes, cudaMemcpyHostToDevice));
+#endif
+#endif // ASSUME_GPU_AWARE_MPI
+#else
+                    // Plain MPI warmup: post WINDOW_SIZE irecvs/isends using iter 0 rows
+                    for (int j = 0; j < W; ++j) {
+                        size_t r = row_index(warm_iter, j, W);
+                        MPI_Irecv(host_recv_win + (size_t)j * bytes_per_row, message, MPI_CHAR,
+                                  partner, tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
+                        MPI_Isend((void*)row_ptr(host_send_2d, bytes_per_row, r), message, MPI_CHAR,
+                                  partner, tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
                     }
-
-                    MPI_Waitall(WINDOW_SIZE, rreqs.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall(WINDOW_SIZE, sreqs.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(W, rreqs.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(W, sreqs.data(), MPI_STATUSES_IGNORE);
 #endif
                 }
 #if defined(USE_CALIPER)
@@ -631,7 +696,7 @@ int main(int argc, char **argv)
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
 
-                // ---------- timed ping-pong (multiple pairs at once) ----------
+                // ---------- timed ping-pong (NO refill; just index 2D rows) ----------
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
@@ -641,59 +706,84 @@ int main(int argc, char **argv)
 
                 MPI_Barrier(MPI_COMM_WORLD);
 
-                for (int i = 0; i < PING_PONG_LIMIT; i++)
+                for (int i = 0; i < ITERS; i++)
                 {
                     double start = 0.0, end = 0.0;
 
-#if defined(USE_HIP)
+#if defined(USE_HIP) || defined(USE_CUDA)
+#if ASSUME_GPU_AWARE_MPI
+                    if (i_am_timing_rank) start = MPI_Wtime();
+
                     if (rank < partner) {
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
+                        for (int j = 0; j < W; ++j) {
+                            size_t r = row_index(i, j, W);
+                            char* d_src = d_send_2d + r * bytes_per_row;
+                            char* d_dst = d_recv_win + (size_t)j * bytes_per_row;
+                            MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
+                            MPI_Recv(d_dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        }
                     } else {
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        for (int j = 0; j < W; ++j) {
+                            size_t r = row_index(i, j, W);
+                            char* d_src = d_send_2d + r * bytes_per_row;
+                            char* d_dst = d_recv_win + (size_t)j * bytes_per_row;
+                            MPI_Recv(d_dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
+                        }
                     }
-#elif defined(USE_CUDA)
-                    if (rank < partner) {
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                    } else {
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                    }
+
+                    if (i_am_timing_rank) end = MPI_Wtime();
 #else
-                    for (int j = 0; j < WINDOW_SIZE; ++j){
-                        fill_with_random_pattern(send_rows[j], (size_t)message);
+                    // Not GPU-aware: MPI uses canonical host 2D rows directly.
+                    if (i_am_timing_rank) start = MPI_Wtime();
+
+                    if (rank < partner) {
+                        for (int j = 0; j < W; ++j) {
+                            size_t r = row_index(i, j, W);
+                            const char* src = row_ptr(host_send_2d, bytes_per_row, r);
+                            char* dst = host_recv_win + (size_t)j * bytes_per_row;
+                            MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
+                            MPI_Recv(dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        }
+                    } else {
+                        for (int j = 0; j < W; ++j) {
+                            size_t r = row_index(i, j, W);
+                            const char* src = row_ptr(host_send_2d, bytes_per_row, r);
+                            char* dst = host_recv_win + (size_t)j * bytes_per_row;
+                            MPI_Recv(dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
+                        }
                     }
 
-                    if (i_am_timing_rank){
-                        start = MPI_Wtime();
+                    // Mirror recv window into device (optional)
+#if defined(USE_HIP)
+                    hipMemcpy(d_recv_win, host_recv_win, recv_window_bytes, hipMemcpyHostToDevice);
+#elif defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(d_recv_win, host_recv_win, recv_window_bytes, cudaMemcpyHostToDevice));
+#endif
+
+                    if (i_am_timing_rank) end = MPI_Wtime();
+#endif // ASSUME_GPU_AWARE_MPI
+#else
+                    if (i_am_timing_rank) start = MPI_Wtime();
+
+                    for (int j = 0; j < W; ++j) {
+                        size_t r = row_index(i, j, W);
+
+                        MPI_Irecv(host_recv_win + (size_t)j * bytes_per_row, message, MPI_CHAR, partner,
+                                  tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
+
+                        MPI_Isend((void*)row_ptr(host_send_2d, bytes_per_row, r), message, MPI_CHAR, partner,
+                                  tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
                     }
 
-                    for (int j = 0; j < WINDOW_SIZE; ++j) {
-                        MPI_Irecv(recv_rows[j], message, MPI_CHAR, partner,
-                                tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
-                    }
+                    MPI_Waitall(W, rreqs.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(W, sreqs.data(), MPI_STATUSES_IGNORE);
 
-                    for (int j = 0; j < WINDOW_SIZE; ++j) {
-                        MPI_Isend(send_rows[j], message, MPI_CHAR, partner,
-                                tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
-                    }
-
-                    MPI_Waitall(WINDOW_SIZE, rreqs.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall(WINDOW_SIZE, sreqs.data(), MPI_STATUSES_IGNORE);
+                    if (i_am_timing_rank) end = MPI_Wtime();
 #endif
 
                     if (i_am_timing_rank) {
-                        end = MPI_Wtime();
                         double rtt = end - start;
                         total_time += rtt;
                         if (rtt < min_rtt) min_rtt = rtt;
@@ -713,7 +803,6 @@ int main(int argc, char **argv)
                     cali_set_double(pp_min_time_sec_attr, min_rtt);
 #endif
 
-                    // Optional: print per-pair stats
                     printf("PINGPONG %s pair (%d,%d): avg=%g s, min=%g s, max=%g s\n",
                            region_label.c_str(), rank, partner,
                            avg_rtt, min_rtt, max_rtt);
@@ -725,23 +814,22 @@ int main(int argc, char **argv)
 
                 // ---------- cleanup ----------
 #if defined(USE_HIP)
-                hipFree(send_buf);
-                hipFree(recv_buf);
+                hipFree(d_send_2d);
+                hipFree(d_recv_win);
 #elif defined(USE_CUDA)
-                cuda_check(cudaFreeHost(h_send));
-                cuda_check(cudaFreeHost(h_recv));
-                cuda_check(cudaFree(d_send));
-                cuda_check(cudaFree(d_recv));
-#else
-                free(send_flat);
-                free(recv_flat);
+                cuda_check(cudaFree(d_send_2d));
+                cuda_check(cudaFree(d_recv_win));
 #endif
+                host_free(host_send_2d);
+                host_free(host_recv_win);
+
             } // end for (partner_rank : partners)
         }     // end if (PingPong || All)
 
         MPI_Barrier(MPI_COMM_WORLD);
 
         // ===================== ALLTOALL =====================
+        // (unchanged from your original; still fills buffers each message-size once)
         if (op == OpKind::Alltoall || op == OpKind::All)
         {
             for (int partner_rank : partners)
@@ -898,6 +986,7 @@ int main(int argc, char **argv)
         MPI_Barrier(MPI_COMM_WORLD);
 
         // ===================== REDUCE =====================
+        // (unchanged)
         if (op == OpKind::Reduce || op == OpKind::All)
         {
             for (int partner_rank : partners)
@@ -1045,6 +1134,7 @@ int main(int argc, char **argv)
         MPI_Barrier(MPI_COMM_WORLD);
 
         // ===================== ALLREDUCE =====================
+        // (unchanged)
         if (op == OpKind::Allreduce || op == OpKind::All)
         {
             for (int partner_rank : partners)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -891,7 +891,7 @@ int main(int argc, char **argv)
                         cali_set_double(aa_avg_time_sec_attr, avg_rtt);
                         cali_set_double(aa_max_time_sec_attr, max_rtt);
                         cali_set_double(aa_min_time_sec_attr, min_rtt);
-                        printf("finished iteration: &d\n" &it);
+                        printf("finished iteration: %d\n" &it);
                         fflush(stdout);
 #endif
                     }

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -104,7 +104,8 @@ static std::vector<RankPair>
 build_pingpong_pairs(const std::string& region_label,
                      int size,
                      int sys_cores_per_socket,
-                     int sys_cores_per_node)
+                     int sys_cores_per_node,
+                     int max_pairs)
 {
     std::vector<RankPair> pairs;
 
@@ -163,6 +164,10 @@ build_pingpong_pairs(const std::string& region_label,
             add_pair(s, s + delta);
     }
 
+    if (max_pairs > 0 && (int)pairs.size() > max_pairs){
+        pairs.resize(max_pairs);
+    }
+
     return pairs;
 }
 
@@ -200,6 +205,7 @@ int main(int argc, char **argv)
     const char *warmup_region_aa = "warmup_aa";
     const char *warmup_region_red = "warmup_red";
     const char *warmup_region_ar = "warmup_ar";
+    int pingpong_num_pairs = 1;
 
     // ---- default to PingPong ----
     OpKind op = OpKind::PingPong;
@@ -457,7 +463,7 @@ int main(int argc, char **argv)
                     build_pingpong_pairs(region_label,
                                          size,
                                          sys_cores_per_socket,
-                                         sys_cores_per_node);
+                                         sys_cores_per_node, pingpong_num_pairs);
 
                 if (pairs.empty()) {
                     if (rank == 0)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -1203,6 +1203,7 @@ int main(int argc, char **argv)
     }
 #endif
 
+    printf("rank %d\n", rank);
     MPI_Finalize();
     return 0;
 }

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -120,9 +120,9 @@ build_pingpong_pairs(const std::string& region_label,
         if (rps < 2) return pairs;
 
         int s0 = 0;
-        int s1 = rps / 4;
-        int s2 = rps / 2;
-        int s3 = rps - 2;
+        int s1 = rps / 8;
+        int s2 = rps / 4;
+        int s3 = (rps / 2) - 2;
 
         add_pair(s0, s0 + 1);
         add_pair(s1, s1 + 1);
@@ -139,10 +139,15 @@ build_pingpong_pairs(const std::string& region_label,
         if (2 * delta > size)
             return pairs; // not enough ranks
 
-        int srcs[4] = { 0, delta / 4, delta / 2, delta - 1 };
+        int s0 = 0;
+        int s1 = delta / 8;
+        int s2 = delta / 4;
+        int s3 = (delta / 2) - 1;
 
-        for (int s : srcs)
-            add_pair(s, s + delta);
+        add_pair(s0, rps / 2);
+        add_pair(s1, (rps / 2) + 1);
+        add_pair(s2, (rps / 2) + 2);
+        add_pair(s3, rps - 1);
 
         return pairs;
     }

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -652,13 +652,13 @@ int main(int argc, char **argv)
                     }
 #else
                     if (rank < partner) {
-                        MPI_ISend(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
-                        MPI_IRecv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Isend(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
+                        MPI_Irecv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
                                  &rreq);
                     } else {
-                        MPI_IRecv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                        MPI_Irecv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
                                  &rreq);
-                        MPI_ISend(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
+                        MPI_Isend(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
                     }
                     MPI_Wait( &rreq, MPI_STATUS_IGNORE);
                     MPI_Wait( &sreq, MPI_STATUS_IGNORE);

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -43,16 +43,15 @@ inline void cuda_check(cudaError_t e) {
 }
 #endif
 
-const char *get_hostname_for_rank(int rank, char all_hostnames[][1024],
-                                  int size) {
+// -------------------- helpers --------------------
+const char *get_hostname_for_rank(int rank, char all_hostnames[][1024], int size) {
     if (rank >= 0 && rank < size) return all_hostnames[rank];
     return "INVALID_RANK";
 }
 
 int extract_node_number(const char *hostname) {
     int len = strlen(hostname);
-    int num = 0;
-    int factor = 1;
+    int num = 0, factor = 1;
     for (int i = len - 1; i >= 0; --i) {
         if (hostname[i] >= '0' && hostname[i] <= '9') {
             num += (hostname[i] - '0') * factor;
@@ -72,6 +71,20 @@ static MPI_Comm make_prefix_subcomm(int active_size) {
     return sub;
 }
 
+enum class P2PMode { PingPong, BW, BiBW };
+
+static P2PMode parse_mode(const char* s) {
+    if (!s) return P2PMode::PingPong;
+    std::string m(s);
+    if (m == "pingpong") return P2PMode::PingPong;
+    if (m == "bw")       return P2PMode::BW;
+    if (m == "bibw")     return P2PMode::BiBW;
+    fprintf(stderr, "Unknown mode '%s' (use pingpong|bw|bibw)\n", s);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+    return P2PMode::PingPong;
+}
+
+// -------------------- main --------------------
 int main(int argc, char **argv) {
     int rank, size;
     MPI_Init(&argc, &argv);
@@ -81,9 +94,18 @@ int main(int argc, char **argv) {
     char my_hostname[1024];
     gethostname(my_hostname, 1023);
     my_hostname[1023] = '\0';
-    char all_hostnames[size][1024];
-    MPI_Gather(my_hostname, 1024, MPI_CHAR, all_hostnames, 1024, MPI_CHAR, 0,
-               MPI_COMM_WORLD);
+    char all_hostnames_local[1024];
+    strncpy(all_hostnames_local, my_hostname, 1024);
+    std::vector<char> all_hostnames_flat(1024 * size, 0);
+    MPI_Allgather(all_hostnames_local, 1024, MPI_CHAR,
+                  all_hostnames_flat.data(), 1024, MPI_CHAR, MPI_COMM_WORLD);
+    // convenience view
+    auto idx = [&](int r){ return &all_hostnames_flat[r*1024]; };
+    // retain old root-gather map for adiak metadata
+    std::vector<char> all_hostnames_root;
+    if (rank == 0) all_hostnames_root.resize(1024 * size);
+    MPI_Gather(my_hostname, 1024, MPI_CHAR,
+               rank==0? all_hostnames_root.data():nullptr, 1024, MPI_CHAR, 0, MPI_COMM_WORLD);
 
 #if defined(USE_CALIPER)
     std::vector<std::string> all_comm_pairs;
@@ -99,6 +121,11 @@ int main(int argc, char **argv) {
     int n_nodes = 1;
     int sys_cores_per_socket = 1;
     int sys_cores_per_node = 1;
+    int bursts = 1;            // NEW
+    int burst_sleep_ms = 0;    // NEW
+    int window = 64;           // NEW (bw/bibw)
+    P2PMode mode = P2PMode::PingPong; // NEW
+    std::string mode_str = "pingpong";
     std::string metadata;
     const char *warmup_region    = "warmup";
     const char *warmup_region_aa = "warmup_aa";
@@ -108,46 +135,62 @@ int main(int argc, char **argv) {
     int opt;
     const char *usage =
         "Usage: %s [-h] [-i n-iterations] [-p rank1,rank2] [-m msg_sz] "
-        "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] [-b metadata]\n";
+        "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] "
+        "[-b metadata] [-r bursts] [-t sleep_ms] [-M pingpong|bw|bibw] [-w window]\n";
 
-    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:")) != -1) {
+    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:r:t:M:w:")) != -1) {
         switch (opt) {
             case 'h':
                 if (rank==0) printf(usage, argv[0]);
-                MPI_Finalize();
-                return 0;
+                MPI_Finalize(); return 0;
             case 'i': PING_PONG_LIMIT = atoi(optarg); break;
-            case 'p': break;
+            case 'p': /* reserved; no-op to keep CLI parity */ break;
             case 'm': msg_size = atoi(optarg); break;
             case 'n': n_nodes = atoi(optarg); break;
             case 's': sys_cores_per_socket = atoi(optarg); break;
             case 'c': sys_cores_per_node = atoi(optarg); break;
             case 'b': metadata = optarg; break;
+            case 'r': bursts = atoi(optarg); break;
+            case 't': burst_sleep_ms = atoi(optarg); break;
+            case 'M': mode = parse_mode(optarg); mode_str = optarg; break;
+            case 'w': window = atoi(optarg); break;
             default:
                 if (rank==0) printf(usage, argv[0]);
                 MPI_Abort(MPI_COMM_WORLD, 1);
         }
     }
+    if (bursts < 1) bursts = 1;
+    if (window < 1) window = 1;
 
     if (rank == 0) {
         printf("Configuration:\n");
-        printf("PING_PONG_LIMIT: %d\n", PING_PONG_LIMIT);
+        printf("PING_PONG_LIMIT (per burst): %d\n", PING_PONG_LIMIT);
         printf("Message size: %d bytes\n", msg_size);
         printf("Cores per socket: %d\n", sys_cores_per_socket);
         printf("Cores per node: %d\n", sys_cores_per_node);
         printf("Nodes: %d\n", n_nodes);
         printf("World size: %d\n", size);
+        printf("Bursts: %d\n", bursts);
+        printf("Sleep between bursts: %d ms\n", burst_sleep_ms);
+        printf("P2P mode: %s\n", mode_str.c_str());
+        if (mode != P2PMode::PingPong) printf("Window: %d\n", window);
 
 #if defined(USE_CALIPER)
-        std::stringstream rankmap;
-        rankmap << "{";
-        for (int i = 0; i < size; ++i) {
-            rankmap << "\"" << i << "\": \"" << all_hostnames[i] << "\"";
-            if (i < size - 1) rankmap << ", ";
+        if (!all_hostnames_root.empty()) {
+            std::stringstream rankmap;
+            rankmap << "{";
+            for (int i = 0; i < size; ++i) {
+                rankmap << "\"" << i << "\": \"" << (&all_hostnames_root[i*1024])[0] << "\"";
+                if (i < size - 1) rankmap << ", ";
+            }
+            rankmap << "}";
+            adiak::value("rank_node_map", rankmap.str());
         }
-        rankmap << "}";
-        adiak::value("rank_node_map", rankmap.str());
         adiak::value("iterations", PING_PONG_LIMIT);
+        adiak::value("bursts", bursts);
+        adiak::value("sleep_ms_between_bursts", burst_sleep_ms);
+        adiak::value("p2p_mode", mode_str);
+        adiak::value("window", window);
 #endif
     }
 
@@ -282,9 +325,8 @@ int main(int argc, char **argv) {
         region_names[1] = "Same Node Same Socket";
     }
 
-    // Build “buckets” (active prefix sizes) for collectives
+    // Build buckets (active prefix sizes) for collectives
     std::vector<int> buckets;
-    // same-node/same-socket (2) if possible
     if (size >= 2) buckets.push_back(2);
     for (int nodes = 2; nodes <= n_nodes; nodes *= 2) {
         int active = nodes * sys_cores_per_node;
@@ -306,29 +348,27 @@ int main(int argc, char **argv) {
         mgr[message].start();
 #endif
 
-        // ------------------------- PINGPONG (WORLD) -------------------------
+        // ------------------------- P2P (WORLD) -------------------------
         for (int partner_rank : partners) {
             std::string region_label = region_names[partner_rank];
-
             if (rank != 0 && rank != partner_rank) continue;
 
             if (rank == 0) {
-                printf("\n--- Testing %s between ranks 0 (%s) and %d (%s), msg=%d ---\n",
+                printf("\n--- Testing %s between ranks 0 (%s) and %d (%s), msg=%d, mode=%s ---\n",
                        region_label.c_str(),
-                       all_hostnames[0], partner_rank, all_hostnames[partner_rank], message);
+                       idx(0), partner_rank, idx(partner_rank), message, mode_str.c_str());
 #if defined(USE_CALIPER)
-                std::string comm_pair = "0(" + std::string(all_hostnames[0]) + ")<->" +
-                                        std::to_string(partner_rank) + "(" + std::string(all_hostnames[partner_rank]) +
+                std::string comm_pair = "0(" + std::string(idx(0)) + ")<->" +
+                                        std::to_string(partner_rank) + "(" + std::string(idx(partner_rank)) +
                                         ")";
                 all_comm_pairs.push_back(comm_pair);
                 cali_set_int(src_rank_attr, 0);
                 cali_set_int(dest_rank_attr, partner_rank);
-                cali_set_int(src_node_attr, extract_node_number(all_hostnames[0]));
-                cali_set_int(dest_node_attr, extract_node_number(all_hostnames[partner_rank]));
+                cali_set_int(src_node_attr, extract_node_number(idx(0)));
+                cali_set_int(dest_node_attr, extract_node_number(idx(partner_rank)));
 #endif
             }
 
-            double total_time = 0.0;
             int warmup = 1;
 
 #if defined(USE_HIP)
@@ -361,84 +401,230 @@ int main(int argc, char **argv) {
             memset(recv_buf, 0, message);
 #endif
 
+            // Warmup
             CALI_MARK_BEGIN(warmup_region);
             for (int i = 0; i < warmup; i++) {
-                if (rank == 0) {
+                if (mode == P2PMode::PingPong) {
+                    if (rank == 0) {
 #if defined(USE_HIP)
-                    MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                    MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 #elif defined(USE_CUDA)
-                    cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                    MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                    MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                    cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
 #else
-                    MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                    MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 #endif
-                } else if (rank == partner_rank) {
+                    } else if (rank == partner_rank) {
 #if defined(USE_HIP)
-                    MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                    MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 #elif defined(USE_CUDA)
-                    MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                    cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                    cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                    MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 #else
-                    MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                    MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 #endif
+                    }
+                } else if (mode == P2PMode::BW) {
+                    // Unidirectional warmup: rank0 sends window msgs, partner receives
+                    if (rank == 0) {
+#if defined(USE_CUDA)
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+#endif
+                        for (int w = 0; w < window; ++w) {
+#if defined(USE_CUDA)
+                            MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+#else
+                            MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+#endif
+                        }
+                    } else if (rank == partner_rank) {
+                        for (int w = 0; w < window; ++w) {
+#if defined(USE_CUDA)
+                            MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+#else
+                            MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+#endif
+                        }
+                    }
+                } else { // BiBW warmup
+                    for (int w = 0; w < window; ++w) {
+#if defined(USE_CUDA)
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Sendrecv(h_send, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                     h_recv, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                        MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                     recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+#else
+                        MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                     recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+#endif
+                    }
                 }
             }
             CALI_MARK_END(warmup_region);
+            MPI_Barrier(MPI_COMM_WORLD);
 
-            CALI_MARK_BEGIN(region_label.c_str());
-            double min_rtt = std::numeric_limits<double>::infinity();
-            double max_rtt = 0.0;
+            // Measurements
+            double total_time = 0.0;
+            double min_t = std::numeric_limits<double>::infinity();
+            double max_t = 0.0;
             int iters = 0;
 
-            for (int i = 0; i < PING_PONG_LIMIT; i++) {
-                if (rank == 0) {
+            CALI_MARK_BEGIN(region_label.c_str());
+
+            for (int b = 0; b < bursts; ++b) {
+                for (int i = 0; i < PING_PONG_LIMIT; i++) {
+                    if (mode == P2PMode::PingPong) {
+                        if (rank == 0) {
 #if defined(USE_CUDA)
-                    double start = MPI_Wtime();
-                    cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                    MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                    MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                    cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                    double end = MPI_Wtime();
+                            double start = MPI_Wtime();
+                            cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                            MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                            MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                            double end = MPI_Wtime();
 #else
-                    double start = MPI_Wtime();
-                    MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                    MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                    double end = MPI_Wtime();
+                            double start = MPI_Wtime();
+                            MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                            MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            double end = MPI_Wtime();
 #endif
-                    double rtt = end - start;
-                    total_time += rtt;
-                    if (rtt < min_rtt) min_rtt = rtt;
-                    if (rtt > max_rtt) max_rtt = rtt;
-                    ++iters;
-                } else if (rank == partner_rank) {
+                            double dt = end - start;
+                            total_time += dt;
+                            if (dt < min_t) min_t = dt;
+                            if (dt > max_t) max_t = dt;
+                            ++iters;
+                        } else if (rank == partner_rank) {
 #if defined(USE_CUDA)
-                    MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                    cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                    cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                    MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+                            MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                            cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                            MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 #else
-                    MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                    MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+                            MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 #endif
-                }
-            }
+                        }
+                    } else if (mode == P2PMode::BW) {
+                        // Rank 0 measures total window send time; receiver just drains.
+                        if (rank == 0) {
+#if defined(USE_CUDA)
+                            cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+#endif
+                            MPI_Barrier(MPI_COMM_WORLD);
+                            double t0 = MPI_Wtime();
+                            for (int w = 0; w < window; ++w) {
+#if defined(USE_CUDA)
+                                MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+#else
+                                MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+#endif
+                            }
+                            double dt = MPI_Wtime() - t0;
+                            total_time += dt;
+                            if (dt < min_t) min_t = dt;
+                            if (dt > max_t) max_t = dt;
+                            ++iters;
+                            MPI_Barrier(MPI_COMM_WORLD);
+                        } else if (rank == partner_rank) {
+                            MPI_Barrier(MPI_COMM_WORLD);
+                            for (int w = 0; w < window; ++w) {
+#if defined(USE_CUDA)
+                                MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                                cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+#else
+                                MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+#endif
+                            }
+                            MPI_Barrier(MPI_COMM_WORLD);
+                        }
+                    } else { // BiBW
+                        // Both measure locally; use max across the two for consistency.
+                        MPI_Barrier(MPI_COMM_WORLD);
+                        double t0 = MPI_Wtime();
+                        for (int w = 0; w < window; ++w) {
+#if defined(USE_CUDA)
+                            cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                            MPI_Sendrecv(h_send, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                         h_recv, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                         MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                            cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                            MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                         recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                         MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+#else
+                            MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                         recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
+                                         MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+#endif
+                        }
+                        double dt = MPI_Wtime() - t0;
+                        double max_dt = 0.0;
+                        MPI_Allreduce(&dt, &max_dt, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+                        if (rank == 0) {
+                            total_time += max_dt;
+                            if (max_dt < min_t) min_t = max_dt;
+                            if (max_dt > max_t) max_t = max_dt;
+                            ++iters;
+                        }
+                        MPI_Barrier(MPI_COMM_WORLD);
+                    }
+                } // iterations
+
+                if (burst_sleep_ms > 0) usleep((useconds_t)burst_sleep_ms * 1000);
+            } // bursts
 
             if (rank == 0) {
-                double avg_rtt = (iters > 0) ? total_time / iters : 0.0;
+                if (mode == P2PMode::PingPong) {
+                    double avg_rtt = (iters > 0) ? total_time / iters : 0.0;
 #if defined(USE_CALIPER)
-                cali_set_string(comm_phase_attr, "pingpong");
-                cali_set_double(pp_avg_time_sec_attr, avg_rtt);
-                cali_set_double(pp_max_time_sec_attr, max_rtt);
-                cali_set_double(pp_min_time_sec_attr, min_rtt);
+                    cali_set_string(comm_phase_attr, "pingpong");
+                    cali_set_double(pp_avg_time_sec_attr, avg_rtt);
+                    cali_set_double(pp_max_time_sec_attr, max_t);
+                    cali_set_double(pp_min_time_sec_attr, min_t);
 #endif
+                    double avg_latency_us = (avg_rtt * 1e6) / 2.0;
+                    double min_latency_us = (min_t * 1e6) / 2.0;
+                    double max_latency_us = (max_t * 1e6) / 2.0;
+                    printf("[PINGPONG] RTT avg=%.6f s min=%.6f s max=%.6f s | latency(one-way) avg=%.1f us min=%.1f us max=%.1f us\n",
+                           avg_rtt, min_t, max_t, avg_latency_us, min_latency_us, max_latency_us);
+                } else if (mode == P2PMode::BW) {
+                    // total bytes per iteration (sender): window * message
+                    double bytes_per_iter = (double)window * (double)message;
+                    double avg_t = (iters > 0) ? total_time / iters : 0.0;
+                    double avg_MBps = (avg_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / avg_t : 0.0;
+                    double avg_Gbps = (avg_t > 0) ? (bytes_per_iter * 8.0 / 1e9) / avg_t : 0.0;
+                    double min_MBps = (max_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / max_t : 0.0; // max time => min bw
+                    double max_MBps = (min_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / min_t : 0.0; // min time => max bw
+                    printf("[BW] window=%d  per-iter-bytes=%.0f  time avg=%.6f s (min=%.6f, max=%.6f)\n",
+                           window, bytes_per_iter, avg_t, min_t, max_t);
+                    printf("     bandwidth avg=%.2f MB/s (%.2f Gb/s) | min=%.2f MB/s | max=%.2f MB/s\n",
+                           avg_MBps, avg_Gbps, min_MBps, max_MBps);
+                } else { // BiBW
+                    double bytes_per_iter = (double)window * (double)message; // per direction
+                    double avg_t = (iters > 0) ? total_time / iters : 0.0;
+                    double avg_MBps_each = (avg_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / avg_t : 0.0;
+                    double avg_Gbps_each = (avg_t > 0) ? (bytes_per_iter * 8.0 / 1e9) / avg_t : 0.0;
+                    printf("[BIBW] window=%d per-iter-bytes(each dir)=%.0f time avg=%.6f s (min=%.6f, max=%.6f)\n",
+                           window, bytes_per_iter, avg_t, min_t, max_t);
+                    printf("       bandwidth each-dir avg=%.2f MB/s (%.2f Gb/s); aggregate≈%.2f MB/s\n",
+                           avg_MBps_each, avg_Gbps_each, 2.0*avg_MBps_each);
+                }
             }
             CALI_MARK_END(region_label.c_str());
 
@@ -521,32 +707,36 @@ int main(int argc, char **argv) {
                 CALI_MARK_END(warmup_region_aa);
 
                 CALI_MARK_BEGIN(region_label.c_str());
-                for (int it = 0; it < PING_PONG_LIMIT; ++it) {
-                    MPI_Barrier(sub);
-                    double t0 = MPI_Wtime();
+                for (int b = 0; b < bursts; ++b) {
+                    for (int it = 0; it < PING_PONG_LIMIT; ++it) {
+                        MPI_Barrier(sub);
+                        double t0 = MPI_Wtime();
 #if defined(USE_HIP)
-                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
-                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR,
-                                 aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, sub);
-                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+                        hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+                        MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR,
+                                     aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, sub);
+                        hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
 #elif defined(USE_CUDA)
-                    cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
-                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR,
-                                 ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
-                    cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
+                        MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR,
+                                     ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
+                        cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
 #else
-                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR,
-                                 aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
+                        MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR,
+                                     aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
 #endif
-                    double dt = MPI_Wtime() - t0;
-                    double iter_max = 0.0;
-                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, sub);
-                    if (sub_rank == 0) {
-                        alltoall_total_time += iter_max;
-                        if (dt < min_rtt) min_rtt = dt;
-                        if (dt > max_rtt) max_rtt = dt;
-                        ++iters;
+                        double dt = MPI_Wtime() - t0;
+                        double iter_max = 0.0;
+                        MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, sub);
+                        if (sub_rank == 0) {
+                            alltoall_total_time += iter_max;
+                            if (dt < min_rtt) min_rtt = dt;
+                            if (dt > max_rtt) max_rtt = dt;
+                            ++iters;
+                        }
                     }
+                    MPI_Barrier(sub);
+                    if (burst_sleep_ms > 0) usleep((useconds_t)burst_sleep_ms * 1000);
                 }
                 CALI_MARK_END(region_label.c_str());
 
@@ -558,6 +748,8 @@ int main(int argc, char **argv) {
                     cali_set_double(aa_max_time_sec_attr, max_rtt);
                     cali_set_double(aa_min_time_sec_attr, min_rtt);
 #endif
+                    printf("[ALLTOALL %d] avg=%.6f s min=%.6f s max=%.6f s\n",
+                           active_size, avg_rtt, min_rtt, max_rtt);
                 }
 
 #if defined(USE_HIP)
@@ -571,7 +763,6 @@ int main(int argc, char **argv) {
 #endif
             }
             if (sub != MPI_COMM_NULL) MPI_Comm_free(&sub);
-
             MPI_Barrier(MPI_COMM_WORLD);
         }
 
@@ -639,29 +830,33 @@ int main(int argc, char **argv) {
                 CALI_MARK_END(warmup_region_red);
 
                 CALI_MARK_BEGIN(region_label.c_str());
-                for (int i = 0; i < PING_PONG_LIMIT; i++) {
-                    MPI_Barrier(sub);
-                    double t0 = MPI_Wtime();
+                for (int b = 0; b < bursts; ++b) {
+                    for (int i = 0; i < PING_PONG_LIMIT; i++) {
+                        MPI_Barrier(sub);
+                        double t0 = MPI_Wtime();
 #if defined(USE_CUDA)
-                    cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
-                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
-                    cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
+                        MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
+                        cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
-                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
-                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+                        hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
+                        MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
+                        hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
 #else
-                    MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
+                        MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
 #endif
-                    double dt = MPI_Wtime() - t0;
-                    double iter_max = 0.0;
-                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, sub);
-                    if (sub_rank == 0) {
-                        red_total_time += iter_max;
-                        if (dt < min_rtt) min_rtt = dt;
-                        if (dt > max_rtt) max_rtt = dt;
-                        ++iters;
+                        double dt = MPI_Wtime() - t0;
+                        double iter_max = 0.0;
+                        MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, sub);
+                        if (sub_rank == 0) {
+                            red_total_time += iter_max;
+                            if (dt < min_rtt) min_rtt = dt;
+                            if (dt > max_rtt) max_rtt = dt;
+                            ++iters;
+                        }
                     }
+                    MPI_Barrier(sub);
+                    if (burst_sleep_ms > 0) usleep((useconds_t)burst_sleep_ms * 1000);
                 }
                 CALI_MARK_END(region_label.c_str());
 
@@ -673,6 +868,8 @@ int main(int argc, char **argv) {
                     cali_set_double(red_max_time_sec_attr, max_rtt);
                     cali_set_double(red_min_time_sec_attr, min_rtt);
 #endif
+                    printf("[REDUCE %d] avg=%.6f s min=%.6f s max=%.6f s\n",
+                           active_size, avg_rtt, min_rtt, max_rtt);
                 }
 
 #if defined(USE_HIP)
@@ -756,29 +953,33 @@ int main(int argc, char **argv) {
                 CALI_MARK_END(warmup_region_ar);
 
                 CALI_MARK_BEGIN(region_label.c_str());
-                for (int i = 0; i < PING_PONG_LIMIT; i++) {
-                    MPI_Barrier(sub);
-                    double t0 = MPI_Wtime();
+                for (int b = 0; b < bursts; ++b) {
+                    for (int i = 0; i < PING_PONG_LIMIT; i++) {
+                        MPI_Barrier(sub);
+                        double t0 = MPI_Wtime();
 #if defined(USE_CUDA)
-                    cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
-                    cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
+                        MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
+                        cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
-                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+                        hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
+                        MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
+                        hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
 #else
-                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
+                        MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
 #endif
-                    double dt = MPI_Wtime() - t0;
-                    double iter_max = 0.0;
-                    MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, sub);
-                    if (sub_rank == 0) {
-                        ar_total_time += iter_max;
-                        if (dt < min_rtt) min_rtt = dt;
-                        if (dt > max_rtt) max_rtt = dt;
-                        ++iters;
+                        double dt = MPI_Wtime() - t0;
+                        double iter_max = 0.0;
+                        MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, sub);
+                        if (sub_rank == 0) {
+                            ar_total_time += iter_max;
+                            if (dt < min_rtt) min_rtt = dt;
+                            if (dt > max_rtt) max_rtt = dt;
+                            ++iters;
+                        }
                     }
+                    MPI_Barrier(sub);
+                    if (burst_sleep_ms > 0) usleep((useconds_t)burst_sleep_ms * 1000);
                 }
                 CALI_MARK_END(region_label.c_str());
 
@@ -790,6 +991,8 @@ int main(int argc, char **argv) {
                     cali_set_double(ar_max_time_sec_attr, max_rtt);
                     cali_set_double(ar_min_time_sec_attr, min_rtt);
 #endif
+                    printf("[ALLREDUCE %d] avg=%.6f s min=%.6f s max=%.6f s\n",
+                           active_size, avg_rtt, min_rtt, max_rtt);
                 }
 
 #if defined(USE_HIP)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -899,7 +899,7 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
 #endif
-                printf("rank &d: end timing\n");
+                printf("rank %d: end timing\n", rank);
                 fflush(stdout);
 
 #if defined(USE_HIP)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -72,6 +72,7 @@ static MPI_Comm make_prefix_subcomm(int active_size) {
 }
 
 enum class P2PMode { PingPong, BW, BiBW };
+enum class OpKind  { PingPong, Alltoall, Reduce, Allreduce };
 
 static P2PMode parse_mode(const char* s) {
     if (!s) return P2PMode::PingPong;
@@ -82,6 +83,18 @@ static P2PMode parse_mode(const char* s) {
     fprintf(stderr, "Unknown mode '%s' (use pingpong|bw|bibw)\n", s);
     MPI_Abort(MPI_COMM_WORLD, 1);
     return P2PMode::PingPong;
+}
+
+static OpKind parse_opkind(const char* s) {
+    if (!s) return OpKind::PingPong;
+    std::string m(s);
+    if (m == "pingpong")  return OpKind::PingPong;
+    if (m == "alltoall")  return OpKind::Alltoall;
+    if (m == "reduce")    return OpKind::Reduce;
+    if (m == "allreduce") return OpKind::Allreduce;
+    fprintf(stderr, "Unknown op '%s' (use pingpong|alltoall|reduce|allreduce)\n", s);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+    return OpKind::PingPong;
 }
 
 // -------------------- main --------------------
@@ -99,9 +112,8 @@ int main(int argc, char **argv) {
     std::vector<char> all_hostnames_flat(1024 * size, 0);
     MPI_Allgather(all_hostnames_local, 1024, MPI_CHAR,
                   all_hostnames_flat.data(), 1024, MPI_CHAR, MPI_COMM_WORLD);
-    // convenience view
     auto idx = [&](int r){ return &all_hostnames_flat[r*1024]; };
-    // retain old root-gather map for adiak metadata
+    // also gather to root for adiak metadata text map
     std::vector<char> all_hostnames_root;
     if (rank == 0) all_hostnames_root.resize(1024 * size);
     MPI_Gather(my_hostname, 1024, MPI_CHAR,
@@ -121,11 +133,13 @@ int main(int argc, char **argv) {
     int n_nodes = 1;
     int sys_cores_per_socket = 1;
     int sys_cores_per_node = 1;
-    int bursts = 1;            // NEW
-    int burst_sleep_ms = 0;    // NEW
-    int window = 64;           // NEW (bw/bibw)
-    P2PMode mode = P2PMode::PingPong; // NEW
+    int bursts = 1;
+    int burst_sleep_ms = 0;
+    int window = 64;                // for bw/bibw
+    P2PMode mode = P2PMode::PingPong;
     std::string mode_str = "pingpong";
+    OpKind op = OpKind::PingPong;   // which operation to run
+    std::string op_str = "pingpong";
     std::string metadata;
     const char *warmup_region    = "warmup";
     const char *warmup_region_aa = "warmup_aa";
@@ -136,15 +150,17 @@ int main(int argc, char **argv) {
     const char *usage =
         "Usage: %s [-h] [-i n-iterations] [-p rank1,rank2] [-m msg_sz] "
         "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] "
-        "[-b metadata] [-r bursts] [-t sleep_ms] [-M pingpong|bw|bibw] [-w window]\n";
+        "[-b metadata] [-r bursts] [-t sleep_ms] "
+        "[-O pingpong|alltoall|reduce|allreduce] "
+        "[-M pingpong|bw|bibw] [-w window]\n";
 
-    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:r:t:M:w:")) != -1) {
+    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:r:t:O:M:w:")) != -1) {
         switch (opt) {
             case 'h':
                 if (rank==0) printf(usage, argv[0]);
                 MPI_Finalize(); return 0;
             case 'i': PING_PONG_LIMIT = atoi(optarg); break;
-            case 'p': /* reserved; no-op to keep CLI parity */ break;
+            case 'p': /* keep CLI parity; unused here */ break;
             case 'm': msg_size = atoi(optarg); break;
             case 'n': n_nodes = atoi(optarg); break;
             case 's': sys_cores_per_socket = atoi(optarg); break;
@@ -152,6 +168,7 @@ int main(int argc, char **argv) {
             case 'b': metadata = optarg; break;
             case 'r': bursts = atoi(optarg); break;
             case 't': burst_sleep_ms = atoi(optarg); break;
+            case 'O': op = parse_opkind(optarg); op_str = optarg; break;
             case 'M': mode = parse_mode(optarg); mode_str = optarg; break;
             case 'w': window = atoi(optarg); break;
             default:
@@ -164,6 +181,8 @@ int main(int argc, char **argv) {
 
     if (rank == 0) {
         printf("Configuration:\n");
+        printf("Operation: %s\n", op_str.c_str());
+        printf("P2P mode (when -O pingpong): %s\n", mode_str.c_str());
         printf("PING_PONG_LIMIT (per burst): %d\n", PING_PONG_LIMIT);
         printf("Message size: %d bytes\n", msg_size);
         printf("Cores per socket: %d\n", sys_cores_per_socket);
@@ -172,7 +191,6 @@ int main(int argc, char **argv) {
         printf("World size: %d\n", size);
         printf("Bursts: %d\n", bursts);
         printf("Sleep between bursts: %d ms\n", burst_sleep_ms);
-        printf("P2P mode: %s\n", mode_str.c_str());
         if (mode != P2PMode::PingPong) printf("Window: %d\n", window);
 
 #if defined(USE_CALIPER)
@@ -186,10 +204,11 @@ int main(int argc, char **argv) {
             rankmap << "}";
             adiak::value("rank_node_map", rankmap.str());
         }
+        adiak::value("operation", op_str);
+        adiak::value("p2p_mode", mode_str);
         adiak::value("iterations", PING_PONG_LIMIT);
         adiak::value("bursts", bursts);
         adiak::value("sleep_ms_between_bursts", burst_sleep_ms);
-        adiak::value("p2p_mode", mode_str);
         adiak::value("window", window);
 #endif
     }
@@ -349,7 +368,7 @@ int main(int argc, char **argv) {
 #endif
 
         // ------------------------- P2P (WORLD) -------------------------
-        for (int partner_rank : partners) {
+        if (op == OpKind::PingPong) for (int partner_rank : partners) {
             std::string region_label = region_names[partner_rank];
             if (rank != 0 && rank != partner_rank) continue;
 
@@ -433,7 +452,7 @@ int main(int argc, char **argv) {
 #endif
                     }
                 } else if (mode == P2PMode::BW) {
-                    // Unidirectional warmup: rank0 sends window msgs, partner receives
+                    // Unidirectional warmup
                     if (rank == 0) {
 #if defined(USE_CUDA)
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
@@ -520,7 +539,6 @@ int main(int argc, char **argv) {
 #endif
                         }
                     } else if (mode == P2PMode::BW) {
-                        // Rank 0 measures total window send time; receiver just drains.
                         if (rank == 0) {
 #if defined(USE_CUDA)
                             cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
@@ -553,7 +571,6 @@ int main(int argc, char **argv) {
                             MPI_Barrier(MPI_COMM_WORLD);
                         }
                     } else { // BiBW
-                        // Both measure locally; use max across the two for consistency.
                         MPI_Barrier(MPI_COMM_WORLD);
                         double t0 = MPI_Wtime();
                         for (int w = 0; w < window; ++w) {
@@ -604,19 +621,18 @@ int main(int argc, char **argv) {
                     printf("[PINGPONG] RTT avg=%.6f s min=%.6f s max=%.6f s | latency(one-way) avg=%.1f us min=%.1f us max=%.1f us\n",
                            avg_rtt, min_t, max_t, avg_latency_us, min_latency_us, max_latency_us);
                 } else if (mode == P2PMode::BW) {
-                    // total bytes per iteration (sender): window * message
                     double bytes_per_iter = (double)window * (double)message;
                     double avg_t = (iters > 0) ? total_time / iters : 0.0;
                     double avg_MBps = (avg_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / avg_t : 0.0;
                     double avg_Gbps = (avg_t > 0) ? (bytes_per_iter * 8.0 / 1e9) / avg_t : 0.0;
-                    double min_MBps = (max_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / max_t : 0.0; // max time => min bw
-                    double max_MBps = (min_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / min_t : 0.0; // min time => max bw
+                    double min_MBps = (max_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / max_t : 0.0;
+                    double max_MBps = (min_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / min_t : 0.0;
                     printf("[BW] window=%d  per-iter-bytes=%.0f  time avg=%.6f s (min=%.6f, max=%.6f)\n",
                            window, bytes_per_iter, avg_t, min_t, max_t);
                     printf("     bandwidth avg=%.2f MB/s (%.2f Gb/s) | min=%.2f MB/s | max=%.2f MB/s\n",
                            avg_MBps, avg_Gbps, min_MBps, max_MBps);
                 } else { // BiBW
-                    double bytes_per_iter = (double)window * (double)message; // per direction
+                    double bytes_per_iter = (double)window * (double)message;
                     double avg_t = (iters > 0) ? total_time / iters : 0.0;
                     double avg_MBps_each = (avg_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / avg_t : 0.0;
                     double avg_Gbps_each = (avg_t > 0) ? (bytes_per_iter * 8.0 / 1e9) / avg_t : 0.0;
@@ -636,13 +652,13 @@ int main(int argc, char **argv) {
 #else
             free(send_buf); free(recv_buf);
 #endif
-        }
+        } // end P2P
 
         // keep everyone aligned before starting collectives
         MPI_Barrier(MPI_COMM_WORLD);
 
         // ------------------------- ALLTOALL (SUBCOMMS) -------------------------
-        for (int active_size : buckets) {
+        if (op == OpKind::Alltoall) for (int active_size : buckets) {
             std::string region_label = "Alltoall_" + std::to_string(active_size);
             MPI_Comm sub = make_prefix_subcomm(active_size);
             int sub_rank=-1, sub_size=0;
@@ -767,7 +783,7 @@ int main(int argc, char **argv) {
         }
 
         // ------------------------- REDUCE (SUBCOMMS) -------------------------
-        for (int active_size : buckets) {
+        if (op == OpKind::Reduce) for (int active_size : buckets) {
             std::string region_label = "Reduce_" + std::to_string(active_size);
             MPI_Comm sub = make_prefix_subcomm(active_size);
             int sub_rank=-1, sub_size=0;
@@ -890,7 +906,7 @@ int main(int argc, char **argv) {
         }
 
         // ------------------------- ALLREDUCE (SUBCOMMS) -------------------------
-        for (int active_size : buckets) {
+        if (op == OpKind::Allreduce) for (int active_size : buckets) {
             std::string region_label = "Allreduce_" + std::to_string(active_size);
             MPI_Comm sub = make_prefix_subcomm(active_size);
             int sub_rank=-1, sub_size=0;

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -169,6 +169,7 @@ build_pingpong_pairs(const std::string& region_label,
             add_pair(off, last_node_base + off);
 
         return pairs;
+    }
 }
 
 int main(int argc, char **argv)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -156,19 +156,19 @@ build_pingpong_pairs(const std::string& region_label,
 
     if (nodes_in_comm >= 2) {
         int rpn   = sys_cores_per_node;
-        int delta = (nodes_in_comm / 2) * rpn;
+        int last_node_base = (nodes_in_comm - 1) * rpn;
 
-        int srcs[4] = { 0, rpn / 4, rpn / 2, rpn - 1 };
+        int offsets[4] = {
+            0,
+            (rpn - 1) / 4,
+            (rpn - 1) / 2,
+            rpn - 1
+        };
 
-        for (int s : srcs)
-            add_pair(s, s + delta);
-    }
+        for (int off : offsets)
+            add_pair(off, last_node_base + off);
 
-    if (max_pairs > 0 && (int)pairs.size() > max_pairs){
-        pairs.resize(max_pairs);
-    }
-
-    return pairs;
+        return pairs;
 }
 
 int main(int argc, char **argv)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -533,29 +533,45 @@ int main(int argc, char **argv)
 
                 // ---------- buffer allocation ----------
 #if defined(USE_HIP)
-                char *send_buf;
-                char *recv_buf;
+                char *send_flat = nullptr;
+                char *recv_flat = nullptr;
 
-                hipError_t err1 = hipMalloc((void**)&send_buf, message);
-                hipError_t err2 = hipMalloc((void**)&recv_buf, message);
+                size_t pp_total_bytes = (size_t)WINDOW_SIZE * (size_t)message;
+
+                hipError_t err1 = hipMalloc((void**)&send_flat, pp_total_bytes);
+                hipError_t err2 = hipMalloc((void**)&recv_flat, pp_total_bytes);
 
                 if (err1 != hipSuccess || err2 != hipSuccess) {
-                    fprintf(stderr, "HIP malloc failed: %s %s\n",
-                            hipGetErrorString(err1),
-                            hipGetErrorString(err2));
+                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(err1), hipGetErrorString(err2));
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
 
-                {
-                    char* h_rand = (char*)malloc(message);
-                    fill_with_random_pattern(h_rand, (size_t)message);
-                    hipError_t cuerr1 =
-                        hipMemcpy(send_buf, h_rand, message, hipMemcpyHostToDevice);
-                    assert(cuerr1 == hipSuccess);
-                    free(h_rand);
+                char *h_tmp = (char*)malloc(pp_total_bytes);
+                if (!h_tmp) {
+                    fprintf(stderr, "Rank %d host malloc failed for %zu bytes\n", rank, pp_total_bytes);
+                    MPI_Abort(MPI_COMM_WORLD, 1);
                 }
-                hipError_t cuerr2 = hipMemset(recv_buf, 0, message);
+
+                fill_with_random_pattern(h_tmp, pp_total_bytes);
+
+                hipError_t cuerr1 = hipMemcpy(send_flat, h_tmp, pp_total_bytes, hipMemcpyHostToDevice);
+                assert(cuerr1 == hipSuccess);
+
+                hipError_t cuerr2 = hipMemset(recv_flat, 0, pp_total_bytes);
                 assert(cuerr2 == hipSuccess);
+
+                free(h_tmp);
+
+                std::vector<char*> s_buf(WINDOW_SIZE);
+                std::vector<char*> r_buf(WINDOW_SIZE);
+
+                for (int j = 0; j < WINDOW_SIZE; ++j) {
+                    s_buf[j] = send_flat + (size_t)j * (size_t)message;
+                    r_buf[j] = recv_flat + (size_t)j * (size_t)message;
+                }
+
+                std::vector<MPI_Request> send_request(WINDOW_SIZE);
+                std::vector<MPI_Request> recv_request(WINDOW_SIZE);
 
 #elif defined(USE_CUDA)
                 int dev_count = 0;
@@ -606,15 +622,16 @@ int main(int argc, char **argv)
                 for (int i = 0; i < warmup; i++)
                 {
 #if defined(USE_HIP)
-                    if (rank < partner) {
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                    } else {
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
+                                MPI_COMM_WORLD, &recv_request[j]);
                     }
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
+                                MPI_COMM_WORLD, &send_request[j]);
+                    }
+                    MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
 #elif defined(USE_CUDA)
                     if (rank < partner) {
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
@@ -665,15 +682,16 @@ int main(int argc, char **argv)
                         start = MPI_Wtime();
 
 #if defined(USE_HIP)
-                    if (rank < partner) {
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                    } else {
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
+                                MPI_COMM_WORLD, &recv_request[j]);
                     }
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
+                                MPI_COMM_WORLD, &send_request[j]);
+                    }
+                    MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
 #elif defined(USE_CUDA)
                     if (rank < partner) {
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
@@ -737,8 +755,8 @@ int main(int argc, char **argv)
 
                 // ---------- cleanup ----------
 #if defined(USE_HIP)
-                hipFree(send_buf);
-                hipFree(recv_buf);
+                hipFree(send_flat);
+                hipFree(recv_flat);
 #elif defined(USE_CUDA)
                 cuda_check(cudaFreeHost(h_send));
                 cuda_check(cudaFreeHost(h_recv));
@@ -855,11 +873,12 @@ int main(int argc, char **argv)
                 for (int i = 0; i < warmup; i++)
                 {
 #if defined(USE_HIP)
-                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
-                    hipDeviceSynchronize();
-                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
-                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
-                    hipDeviceSynchronize();
+                    // hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+                    // hipDeviceSynchronize();
+                    // MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
+                    // hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+                    // hipDeviceSynchronize();
+                    MPI_Alltoall(aa_send_dev, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_dev, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
 #elif defined(USE_CUDA)
                     cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
                     MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
@@ -888,11 +907,12 @@ int main(int argc, char **argv)
                 for (int it = 0; it < num_iterations; ++it)
                 {
 #if defined(USE_HIP)
-                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
-                    hipDeviceSynchronize();
-                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
-                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
-                    hipDeviceSynchronize();
+                    // hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+                    // hipDeviceSynchronize();
+                    // MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
+                    // hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+                    // hipDeviceSynchronize();
+                    MPI_Alltoall(aa_send_dev, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_dev, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
 #elif defined(USE_CUDA)
                     cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
                     MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
@@ -1028,9 +1048,10 @@ int main(int argc, char **argv)
                     MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
                     cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
-                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
-                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+                    // hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
+                    // MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    // hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+                    MPI_Reduce(rd_d_send, rd_d_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
                     MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
 #endif
@@ -1057,9 +1078,10 @@ int main(int argc, char **argv)
                     MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
                     cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
-                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
-                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+                    // hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
+                    // MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    // hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+                    MPI_Reduce(rd_d_send, rd_d_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
                     MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
 #endif
@@ -1207,9 +1229,10 @@ int main(int argc, char **argv)
                     MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
                     cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
-                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+                    // hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
+                    // MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
+                    // hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+                    MPI_Allreduce(ar_d_send, ar_d_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
 #else
                     MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
 #endif
@@ -1237,9 +1260,10 @@ int main(int argc, char **argv)
                     MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
                     cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
-                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+                    // hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
+                    // MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
+                    // hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+                    MPI_Allreduce(ar_d_send, ar_d_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
 #else
                     MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM,region_comm);
 #endif

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -43,14 +43,9 @@ inline void cuda_check(cudaError_t e) {
 }
 #endif
 
-// -------------------- helpers --------------------
-const char *get_hostname_for_rank(int rank, char all_hostnames[][1024], int size) {
-    if (rank >= 0 && rank < size) return all_hostnames[rank];
-    return "INVALID_RANK";
-}
-
-int extract_node_number(const char *hostname) {
-    int len = strlen(hostname);
+// ------------ helpers ------------
+static int extract_node_number(const char *hostname) {
+    int len = (int)strlen(hostname);
     int num = 0, factor = 1;
     for (int i = len - 1; i >= 0; --i) {
         if (hostname[i] >= '0' && hostname[i] <= '9') {
@@ -61,38 +56,7 @@ int extract_node_number(const char *hostname) {
     return num;
 }
 
-// Make a prefix subcommunicator: ranks [0..active_size-1]
-static MPI_Comm make_prefix_subcomm(int active_size) {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    int color = (rank < active_size) ? 1 : MPI_UNDEFINED;
-    MPI_Comm sub = MPI_COMM_NULL;
-    MPI_Comm_split(MPI_COMM_WORLD, color, rank, &sub);
-    return sub;
-}
-
-// Make a communicator for the pair {0, partner_rank}
-static MPI_Comm make_pair_comm(int partner_rank) {
-    int rank; MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    int color = (rank == 0 || rank == partner_rank) ? (1000 + partner_rank) : MPI_UNDEFINED;
-    MPI_Comm sub = MPI_COMM_NULL;
-    MPI_Comm_split(MPI_COMM_WORLD, color, rank, &sub);
-    return sub;
-}
-
-enum class P2PMode { PingPong, BW, BiBW };
-enum class OpKind  { PingPong, Alltoall, Reduce, Allreduce };
-
-static P2PMode parse_mode(const char* s) {
-    if (!s) return P2PMode::PingPong;
-    std::string m(s);
-    if (m == "pingpong") return P2PMode::PingPong;
-    if (m == "bw")       return P2PMode::BW;
-    if (m == "bibw")     return P2PMode::BiBW;
-    fprintf(stderr, "Unknown mode '%s' (use pingpong|bw|bibw)\n", s);
-    MPI_Abort(MPI_COMM_WORLD, 1);
-    return P2PMode::PingPong;
-}
+enum class OpKind { PingPong, Alltoall, Reduce, Allreduce };
 
 static OpKind parse_opkind(const char* s) {
     if (!s) return OpKind::PingPong;
@@ -101,164 +65,117 @@ static OpKind parse_opkind(const char* s) {
     if (m == "alltoall")  return OpKind::Alltoall;
     if (m == "reduce")    return OpKind::Reduce;
     if (m == "allreduce") return OpKind::Allreduce;
-    fprintf(stderr, "Unknown op '%s' (use pingpong|alltoall|reduce|allreduce)\n", s);
-    MPI_Abort(MPI_COMM_WORLD, 1);
+    fprintf(stderr, "Unknown -O option '%s' (use pingpong|alltoall|reduce|allreduce)\n", s);
+    MPI_Abort(MPI_COMM_WORLD, 2);
     return OpKind::PingPong;
 }
 
-// -------------------- main --------------------
+// ------------ main ------------
 int main(int argc, char **argv) {
     int rank, size;
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
+    // gather hostnames to rank 0 for printing/adiak
     char my_hostname[1024];
     gethostname(my_hostname, 1023);
     my_hostname[1023] = '\0';
-    char all_hostnames_local[1024];
-    strncpy(all_hostnames_local, my_hostname, 1024);
-    std::vector<char> all_hostnames_flat(1024 * size, 0);
-    MPI_Allgather(all_hostnames_local, 1024, MPI_CHAR,
-                  all_hostnames_flat.data(), 1024, MPI_CHAR, MPI_COMM_WORLD);
-    auto idx = [&](int r){ return &all_hostnames_flat[r*1024]; };
-    // also gather to root for adiak metadata text map
-    std::vector<char> all_hostnames_root;
-    if (rank == 0) all_hostnames_root.resize(1024 * size);
+    std::vector<char> all_hostnames;
+    if (rank == 0) all_hostnames.resize(1024 * size, 0);
     MPI_Gather(my_hostname, 1024, MPI_CHAR,
-               rank==0? all_hostnames_root.data():nullptr, 1024, MPI_CHAR, 0, MPI_COMM_WORLD);
+               rank==0? all_hostnames.data():nullptr, 1024, MPI_CHAR, 0, MPI_COMM_WORLD);
+    auto host = [&](int r){ return rank==0? &all_hostnames[r*1024] : my_hostname; };
 
 #if defined(USE_CALIPER)
-    std::vector<std::string> all_comm_pairs;
     static std::map<int, cali::ConfigManager> mgr;
+    std::vector<std::string> all_comm_pairs;
     MPI_Comm adiak_comm = MPI_COMM_WORLD;
     adiak::init(&adiak_comm);
     adiak::collect_all();
     CALI_CXX_MARK_FUNCTION;
 #endif
 
+    // params
     int PING_PONG_LIMIT = 10;
     int msg_size = 1;
     int n_nodes = 1;
     int sys_cores_per_socket = 1;
     int sys_cores_per_node = 1;
-    int bursts = 1;
-    int burst_sleep_ms = 0;
-    int window = 64;                // for bw/bibw
-    P2PMode mode = P2PMode::PingPong;
-    std::string mode_str = "pingpong";
-    OpKind op = OpKind::PingPong;   // which operation to run
-    std::string op_str = "pingpong";
     std::string metadata;
+    OpKind op = OpKind::PingPong;
+
     const char *warmup_region    = "warmup";
     const char *warmup_region_aa = "warmup_aa";
     const char *warmup_region_red= "warmup_red";
     const char *warmup_region_ar = "warmup_ar";
 
-    int opt;
     const char *usage =
-        "Usage: %s [-h] [-i n-iterations] [-p rank1,rank2] [-m msg_sz] "
-        "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] "
-        "[-b metadata] [-r bursts] [-t sleep_ms] "
-        "[-O pingpong|alltoall|reduce|allreduce] "
-        "[-M pingpong|bw|bibw] [-w window]\n";
+        "Usage: %s [-h] [-i iters] [-m msg_sz] [-n n_nodes] [-s cores/socket] [-c cores/node] [-b metadata] "
+        "[-O pingpong|alltoall|reduce|allreduce]\n";
 
-    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:r:t:O:M:w:")) != -1) {
+    int opt;
+    while ((opt = getopt(argc, argv, "hi:m:n:s:c:b:O:")) != -1) {
         switch (opt) {
-            case 'h':
-                if (rank==0) printf(usage, argv[0]);
-                MPI_Finalize(); return 0;
+            case 'h': if (rank==0) printf(usage, argv[0]); MPI_Finalize(); return 0;
             case 'i': PING_PONG_LIMIT = atoi(optarg); break;
-            case 'p': /* keep CLI parity; unused here */ break;
             case 'm': msg_size = atoi(optarg); break;
             case 'n': n_nodes = atoi(optarg); break;
             case 's': sys_cores_per_socket = atoi(optarg); break;
             case 'c': sys_cores_per_node = atoi(optarg); break;
             case 'b': metadata = optarg; break;
-            case 'r': bursts = atoi(optarg); break;
-            case 't': burst_sleep_ms = atoi(optarg); break;
-            case 'O': op = parse_opkind(optarg); op_str = optarg; break;
-            case 'M': mode = parse_mode(optarg); mode_str = optarg; break;
-            case 'w': window = atoi(optarg); break;
-            default:
-                if (rank==0) printf(usage, argv[0]);
-                MPI_Abort(MPI_COMM_WORLD, 1);
+            case 'O': op = parse_opkind(optarg); break;
+            default:  if (rank==0) printf(usage, argv[0]); MPI_Abort(MPI_COMM_WORLD, 1);
         }
     }
-    if (bursts < 1) bursts = 1;
-    if (window < 1) window = 1;
 
     if (rank == 0) {
         printf("Configuration:\n");
-        printf("Operation: %s\n", op_str.c_str());
-        printf("P2P mode (when -O pingpong): %s\n", mode_str.c_str());
-        printf("PING_PONG_LIMIT (per burst): %d\n", PING_PONG_LIMIT);
+        printf("Operation: %s\n",
+               op==OpKind::PingPong ? "pingpong" :
+               op==OpKind::Alltoall ? "alltoall" :
+               op==OpKind::Reduce   ? "reduce"   : "allreduce");
+        printf("PING_PONG_LIMIT: %d\n", PING_PONG_LIMIT);
         printf("Message size: %d bytes\n", msg_size);
         printf("Cores per socket: %d\n", sys_cores_per_socket);
         printf("Cores per node: %d\n", sys_cores_per_node);
         printf("Nodes: %d\n", n_nodes);
         printf("World size: %d\n", size);
-        printf("Bursts: %d\n", bursts);
-        printf("Sleep between bursts: %d ms\n", burst_sleep_ms);
-        if (mode != P2PMode::PingPong) printf("Window: %d\n", window);
 
 #if defined(USE_CALIPER)
-        if (!all_hostnames_root.empty()) {
-            std::stringstream rankmap;
-            rankmap << "{";
-            for (int i = 0; i < size; ++i) {
-                rankmap << "\"" << i << "\": \"" << (&all_hostnames_root[i*1024])[0] << "\"";
-                if (i < size - 1) rankmap << ", ";
-            }
-            rankmap << "}";
-            adiak::value("rank_node_map", rankmap.str());
+        // rank->host map
+        std::stringstream rankmap;
+        rankmap << "{";
+        for (int i = 0; i < size; ++i) {
+            rankmap << "\"" << i << "\": \"" << (&all_hostnames[i*1024])[0] << "\"";
+            if (i < size - 1) rankmap << ", ";
         }
-        adiak::value("operation", op_str);
-        adiak::value("p2p_mode", mode_str);
+        rankmap << "}";
+        adiak::value("rank_node_map", rankmap.str());
         adiak::value("iterations", PING_PONG_LIMIT);
-        adiak::value("bursts", bursts);
-        adiak::value("sleep_ms_between_bursts", burst_sleep_ms);
-        adiak::value("window", window);
 #endif
     }
 
 #if defined(USE_CALIPER)
-    cali_id_t src_rank_attr = cali_create_attribute("src_rank", CALI_TYPE_INT,
-                              CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t dest_rank_attr = cali_create_attribute("dest_rank", CALI_TYPE_INT,
-                               CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t src_node_attr = cali_create_attribute("src_node", CALI_TYPE_INT,
-                              CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t dest_node_attr = cali_create_attribute("dest_node", CALI_TYPE_INT,
-                               CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t message_size_attr = cali_create_attribute("message_size_bytes",
-                                  CALI_TYPE_INT, CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t comm_phase_attr = cali_create_attribute("comm_phase", CALI_TYPE_STRING,
-                                CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t aa_avg_time_sec_attr = cali_create_attribute("aa_avg_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t aa_max_time_sec_attr = cali_create_attribute("aa_max_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t aa_min_time_sec_attr = cali_create_attribute("aa_min_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t pp_avg_time_sec_attr = cali_create_attribute("pp_avg_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t pp_max_time_sec_attr = cali_create_attribute("pp_max_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t pp_min_time_sec_attr = cali_create_attribute("pp_min_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t red_avg_time_sec_attr = cali_create_attribute("red_avg_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t red_max_time_sec_attr = cali_create_attribute("red_max_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t red_min_time_sec_attr = cali_create_attribute("red_min_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t ar_avg_time_sec_attr  = cali_create_attribute("ar_avg_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t ar_max_time_sec_attr  = cali_create_attribute("ar_max_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
-    cali_id_t ar_min_time_sec_attr  = cali_create_attribute("ar_min_time_sec", CALI_TYPE_DOUBLE,
-                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    // attributes
+    cali_id_t src_rank_attr = cali_create_attribute("src_rank", CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t dest_rank_attr= cali_create_attribute("dest_rank",CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t src_node_attr = cali_create_attribute("src_node", CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t dest_node_attr= cali_create_attribute("dest_node",CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t message_size_attr = cali_create_attribute("message_size_bytes", CALI_TYPE_INT, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t comm_phase_attr   = cali_create_attribute("comm_phase",        CALI_TYPE_STRING, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t aa_avg_time_sec_attr = cali_create_attribute("aa_avg_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t aa_max_time_sec_attr = cali_create_attribute("aa_max_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t aa_min_time_sec_attr = cali_create_attribute("aa_min_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t pp_avg_time_sec_attr = cali_create_attribute("pp_avg_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t pp_max_time_sec_attr = cali_create_attribute("pp_max_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t pp_min_time_sec_attr = cali_create_attribute("pp_min_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t red_avg_time_sec_attr= cali_create_attribute("red_avg_time_sec",CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t red_max_time_sec_attr= cali_create_attribute("red_max_time_sec",CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t red_min_time_sec_attr= cali_create_attribute("red_min_time_sec",CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t ar_avg_time_sec_attr = cali_create_attribute("ar_avg_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t ar_max_time_sec_attr = cali_create_attribute("ar_max_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
+    cali_id_t ar_min_time_sec_attr = cali_create_attribute("ar_min_time_sec", CALI_TYPE_DOUBLE, CALI_ATTR_ASVALUE|CALI_ATTR_AGGREGATABLE);
 
     const char *src_dest_attributes = R"json(
         {
@@ -266,58 +183,53 @@ int main(int argc, char **argv) {
             "type": "boolean",
             "category": "metric",
             "description": "Collect pingpong attributes",
-            "query":
-            [
-            {
-                "level": "local",
-                "select":
-                [
-                {"expr": "any(max#src_rank)", "as": "src_rank"},
-                {"expr": "any(max#dest_rank)", "as": "dest_rank"},
-                {"expr": "any(max#src_node)", "as": "src_node"},
-                {"expr": "any(max#dest_node)", "as": "dest_node"},
-                {"expr": "any(max#message_size_bytes)", "as": "message_size_bytes"},
-                {"expr": "any(max#comm_phase)", "as" : "comm_phase"},
-                {"expr": "any(max#aa_avg_time_sec)", "as" : "aa_avg_s"},
-                {"expr": "any(max#aa_max_time_sec)", "as" : "aa_max_s"},
-                {"expr": "any(max#aa_min_time_sec)", "as" : "aa_min_s"},
-                {"expr": "any(max#pp_avg_time_sec)", "as" : "pp_avg_s"},
-                {"expr": "any(max#pp_max_time_sec)", "as" : "pp_max_s"},
-                {"expr": "any(max#pp_min_time_sec)", "as" : "pp_min_s"},
-                {"expr": "any(max#red_avg_time_sec)", "as" : "red_avg_s"},
-                {"expr": "any(max#red_max_time_sec)", "as" : "red_max_s"},
-                {"expr": "any(max#red_min_time_sec)", "as" : "red_min_s"},
-                {"expr": "any(max#ar_avg_time_sec)", "as" : "ar_avg_s"},
-                {"expr": "any(max#ar_max_time_sec)", "as" : "ar_max_s"},
-                {"expr": "any(max#ar_min_time_sec)", "as" : "ar_min_s"}
-                ],
-                "group by": ["comm_phase"]
-            },
-            {
-                "level": "cross",
-                "select":
-                [
-                {"expr": "any(any#max#src_rank)", "as": "src_rank"},
-                {"expr": "any(any#max#dest_rank)", "as": "dest_rank"},
-                {"expr": "any(any#max#src_node)", "as": "src_node"},
-                {"expr": "any(any#max#dest_node)", "as": "dest_node"},
-                {"expr": "any(any#max#message_size_bytes)", "as": "message_size_bytes"},
-                {"expr": "any(any#max#comm_phase)", "as" : "comm_phase"},
-                {"expr": "any(any#max#aa_avg_time_sec)", "as" : "aa_avg_s"},
-                {"expr": "any(any#max#aa_max_time_sec)", "as" : "aa_max_s"},
-                {"expr": "any(any#max#aa_min_time_sec)", "as" : "aa_min_s"},
-                {"expr": "any(any#max#pp_avg_time_sec)", "as" : "pp_avg_s"},
-                {"expr": "any(any#max#pp_max_time_sec)", "as" : "pp_max_s"},
-                {"expr": "any(any#max#pp_min_time_sec)", "as" : "pp_min_s"},
-                {"expr": "any(any#max#red_avg_time_sec)", "as" : "red_avg_s"},
-                {"expr": "any(any#max#red_max_time_sec)", "as" : "red_max_s"},
-                {"expr": "any(any#max#red_min_time_sec)", "as" : "red_min_s"},
-                {"expr": "any(any#max#ar_avg_time_sec)", "as" : "ar_avg_s"},
-                {"expr": "any(any#max#ar_max_time_sec)", "as" : "ar_max_s"},
-                {"expr": "any(any#max#ar_min_time_sec)", "as" : "ar_min_s"}
-                ],
-                "group by": ["comm_phase"]
-            }
+            "query": [
+                {
+                    "level": "local",
+                    "select": [
+                        {"expr": "any(max#src_rank)", "as": "src_rank"},
+                        {"expr": "any(max#dest_rank)", "as": "dest_rank"},
+                        {"expr": "any(max#src_node)", "as": "src_node"},
+                        {"expr": "any(max#dest_node)", "as": "dest_node"},
+                        {"expr": "any(max#message_size_bytes)", "as": "message_size_bytes"},
+                        {"expr": "any(max#aa_avg_time_sec)", "as" : "aa_avg_s"},
+                        {"expr": "any(max#aa_max_time_sec)", "as" : "aa_max_s"},
+                        {"expr": "any(max#aa_min_time_sec)", "as" : "aa_min_s"},
+                        {"expr": "any(max#pp_avg_time_sec)", "as" : "pp_avg_s"},
+                        {"expr": "any(max#pp_max_time_sec)", "as" : "pp_max_s"},
+                        {"expr": "any(max#pp_min_time_sec)", "as" : "pp_min_s"},
+                        {"expr": "any(max#red_avg_time_sec)", "as" : "red_avg_s"},
+                        {"expr": "any(max#red_max_time_sec)", "as" : "red_max_s"},
+                        {"expr": "any(max#red_min_time_sec)", "as" : "red_min_s"},
+                        {"expr": "any(max#ar_avg_time_sec)", "as" : "ar_avg_s"},
+                        {"expr": "any(max#ar_max_time_sec)", "as" : "ar_max_s"},
+                        {"expr": "any(max#ar_min_time_sec)", "as" : "ar_min_s"}
+                    ],
+                    "group by": ["comm_phase"]
+                },
+                {
+                    "level": "cross",
+                    "select": [
+                        {"expr": "any(any#max#src_rank)", "as": "src_rank"},
+                        {"expr": "any(any#max#dest_rank)", "as": "dest_rank"},
+                        {"expr": "any(any#max#src_node)", "as": "src_node"},
+                        {"expr": "any(any#max#dest_node)", "as": "dest_node"},
+                        {"expr": "any(any#max#message_size_bytes)", "as": "message_size_bytes"},
+                        {"expr": "any(any#max#aa_avg_time_sec)", "as" : "aa_avg_s"},
+                        {"expr": "any(any#max#aa_max_time_sec)", "as" : "aa_max_s"},
+                        {"expr": "any(any#max#aa_min_time_sec)", "as" : "aa_min_s"},
+                        {"expr": "any(any#max#pp_avg_time_sec)", "as" : "pp_avg_s"},
+                        {"expr": "any(any#max#pp_max_time_sec)", "as" : "pp_max_s"},
+                        {"expr": "any(any#max#pp_min_time_sec)", "as" : "pp_min_s"},
+                        {"expr": "any(any#max#red_avg_time_sec)", "as" : "red_avg_s"},
+                        {"expr": "any(any#max#red_max_time_sec)", "as" : "red_max_s"},
+                        {"expr": "any(any#max#red_min_time_sec)", "as" : "red_min_s"},
+                        {"expr": "any(any#max#ar_avg_time_sec)", "as" : "ar_avg_s"},
+                        {"expr": "any(any#max#ar_max_time_sec)", "as" : "ar_max_s"},
+                        {"expr": "any(any#max#ar_min_time_sec)", "as" : "ar_min_s"}
+                    ],
+                    "group by": ["comm_phase"]
+                }
             ]
         }
     )json";
@@ -328,727 +240,436 @@ int main(int argc, char **argv) {
     std::stringstream timestamp;
     timestamp << std::put_time(std::localtime(&now_time), "%Y%m%d_%H%M%S");
 
+    // Build partner list for pingpong (0 <-> last rank of each bucket)
     int P = sys_cores_per_node * n_nodes;
     std::vector<int> partners;
-    std::map<int, std::string> region_names;
-
+    std::map<int,std::string> region_names;
     int current_nodes = n_nodes;
     int current_p = P;
-
     while (current_p > 2) {
         int partner_rank = current_p - 1;
-        std::string label;
-        if (current_nodes >= 2) label = std::to_string(current_nodes) + " nodes";
-        else label = "Same Node Different Socket";
-
+        std::string label = (current_nodes >= 2) ? std::to_string(current_nodes) + " nodes"
+                                                 : "Same Node Different Socket";
         if (partner_rank > 0 && partner_rank < size) {
             partners.push_back(partner_rank);
             region_names[partner_rank] = label;
         }
-        current_nodes = current_nodes / 2;
+        current_nodes /= 2;
         current_p = current_nodes * sys_cores_per_node;
     }
-    if (1 < size) {
+    if (size > 1) {
         partners.push_back(1);
         region_names[1] = "Same Node Same Socket";
     }
 
-    // Build buckets (active prefix sizes) for collectives
-    std::vector<int> buckets;
-    if (size >= 2) buckets.push_back(2);
-    for (int nodes = 2; nodes <= n_nodes; nodes *= 2) {
-        int active = nodes * sys_cores_per_node;
-        if (active <= size) buckets.push_back(active);
-    }
-
+    // sweep message sizes
     for (int message = msg_size; message <= (int)std::pow((double)msg_size, 6.0); message *= 8) {
 #if defined(USE_CALIPER)
-        std::string profile = "spot(output=" + std::to_string(message) + "_" +
-                              timestamp.str() +
-                              ".cali, profile.mpi)"
-                              + (metadata.empty() ? "" : (",metadata(file=" + metadata + ")")) +
-                              ",metadata(file=/etc/node_info.json,keys=\"host.os\")";
-        cali_set_int(message_size_attr, message);
+        std::string profile = "spot(output=" + std::to_string(message) + "_" + timestamp.str()
+                            + ".cali, profile.mpi)"
+                            + (metadata.empty() ? "" : (",metadata(file=" + metadata + ")"))
+                            + ",metadata(file=/etc/node_info.json,keys=\"host.os\")";
         mgr[message].add_option_spec(src_dest_attributes);
         mgr[message].set_default_parameter("pingpong_attributes", "true");
+        cali_set_int(message_size_attr, message);
         adiak::value("message_size", message);
         mgr[message].add(profile.c_str());
         mgr[message].start();
 #endif
 
-        // ------------------------- P2P (WORLD) -------------------------
-        if (op == OpKind::PingPong) for (int partner_rank : partners) {
-            std::string region_label = region_names[partner_rank];
-            if (rank != 0 && rank != partner_rank) continue;
+        // ---------------- PINGPONG (selected) ----------------
+        if (op == OpKind::PingPong) {
+            for (int partner_rank : partners) {
+                if (rank != 0 && rank != partner_rank) continue;
 
-            // pair communicator for ranks {0, partner_rank}
-            MPI_Comm pair = make_pair_comm(partner_rank);
-            int pair_rank=-1, pair_size=0;
-            if (pair != MPI_COMM_NULL) { MPI_Comm_rank(pair,&pair_rank); MPI_Comm_size(pair,&pair_size); }
-
-            if (rank == 0) {
-                printf("\n--- Testing %s between ranks 0 (%s) and %d (%s), msg=%d, mode=%s ---\n",
-                       region_label.c_str(),
-                       idx(0), partner_rank, idx(partner_rank), message, mode_str.c_str());
+                std::string region_label = region_names[partner_rank];
+                if (rank == 0) {
+                    printf("\n--- PINGPONG %s: 0 (%s) <-> %d (%s), msg=%d ---\n",
+                           region_label.c_str(),
+                           &all_hostnames[0],
+                           partner_rank, &all_hostnames[partner_rank*1024], message);
 #if defined(USE_CALIPER)
-                std::string comm_pair = "0(" + std::string(idx(0)) + ")<->" +
-                                        std::to_string(partner_rank) + "(" + std::string(idx(partner_rank)) +
-                                        ")";
-                all_comm_pairs.push_back(comm_pair);
-                cali_set_int(src_rank_attr, 0);
-                cali_set_int(dest_rank_attr, partner_rank);
-                cali_set_int(src_node_attr, extract_node_number(idx(0)));
-                cali_set_int(dest_node_attr, extract_node_number(idx(partner_rank)));
+                    std::string comm_pair = "0(" + std::string(&all_hostnames[0]) + ")<->" +
+                                            std::to_string(partner_rank) + "(" + std::string(&all_hostnames[partner_rank*1024]) + ")";
+                    all_comm_pairs.push_back(comm_pair);
+                    cali_set_int(src_rank_attr, 0);
+                    cali_set_int(dest_rank_attr, partner_rank);
+                    cali_set_int(src_node_attr, extract_node_number(&all_hostnames[0]));
+                    cali_set_int(dest_node_attr, extract_node_number(&all_hostnames[partner_rank*1024]));
 #endif
-            }
+                }
 
-            int warmup = 1;
+                int warmup = 1;
+                double total_time = 0.0;
+                double min_rtt = std::numeric_limits<double>::infinity();
+                double max_rtt = 0.0;
+                int iters = 0;
 
 #if defined(USE_HIP)
-            char *send_buf;   char *recv_buf;
-            hipError_t err1 = hipMalloc((void**)&send_buf, message);
-            hipError_t err2 = hipMalloc((void**)&recv_buf, message);
-            if (err1 != hipSuccess || err2 != hipSuccess) {
-                fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(err1), hipGetErrorString(err2));
-                MPI_Abort(MPI_COMM_WORLD, 1);
-            }
-            hipError_t cuerr1 = hipMemset(send_buf, 'a', message); assert(cuerr1 == hipSuccess);
-            hipError_t cuerr2 = hipMemset(recv_buf, 0, message);   assert(cuerr2 == hipSuccess);
+                char *send_buf; char *recv_buf;
+                hipMalloc((void**)&send_buf, message); hipMalloc((void**)&recv_buf, message);
+                hipMemset(send_buf,'a',message); hipMemset(recv_buf,0,message);
 #elif defined(USE_CUDA)
-            int dev_count = 0; cuda_check(cudaGetDeviceCount(&dev_count));
-            cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
-            char *d_send = nullptr; char *d_recv = nullptr;
-            cuda_check(cudaMalloc((void**)&d_send, message));
-            cuda_check(cudaMalloc((void**)&d_recv, message));
-            cuda_check(cudaMemset(d_send, 'a', message));
-            cuda_check(cudaMemset(d_recv, 0, message));
-            char *h_send = nullptr, *h_recv = nullptr;
-            cuda_check(cudaMallocHost((void**)&h_send, message));
-            cuda_check(cudaMallocHost((void**)&h_recv, message));
-            memset(h_send, 'a', message);
-            memset(h_recv, 0, message);
+                int dev_count=0; cuda_check(cudaGetDeviceCount(&dev_count));
+                cuda_check(cudaSetDevice(rank % (dev_count>0?dev_count:1)));
+                char *d_send=nullptr,*d_recv=nullptr; cuda_check(cudaMalloc((void**)&d_send,message));
+                cuda_check(cudaMalloc((void**)&d_recv,message));
+                cuda_check(cudaMemset(d_send,'a',message)); cuda_check(cudaMemset(d_recv,0,message));
+                char *h_send=nullptr,*h_recv=nullptr;
+                cuda_check(cudaMallocHost((void**)&h_send,message));
+                cuda_check(cudaMallocHost((void**)&h_recv,message));
+                memset(h_send,'a',message); memset(h_recv,0,message);
 #else
-            char *send_buf = (char *)malloc(message);
-            char *recv_buf = (char *)malloc(message);
-            memset(send_buf, 'a', message);
-            memset(recv_buf, 0, message);
+                char *send_buf=(char*)malloc(message), *recv_buf=(char*)malloc(message);
+                memset(send_buf,'a',message); memset(recv_buf,0,message);
 #endif
 
-            // Warmup
-            CALI_MARK_BEGIN(warmup_region);
-            for (int i = 0; i < warmup; i++) {
-                if (mode == P2PMode::PingPong) {
-                    if (rank == 0) {
-#if defined(USE_HIP)
-                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-#elif defined(USE_CUDA)
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-#else
-                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-#endif
-                    } else if (rank == partner_rank) {
-#if defined(USE_HIP)
-                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
-#elif defined(USE_CUDA)
-                        MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
-#else
-                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
-#endif
-                    }
-                } else if (mode == P2PMode::BW) {
-                    // Unidirectional warmup
-                    if (rank == 0) {
+                CALI_MARK_BEGIN(warmup_region);
+                for (int i=0;i<warmup;i++) {
+                    if (rank==0) {
 #if defined(USE_CUDA)
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-#endif
-                        for (int w = 0; w < window; ++w) {
-#if defined(USE_CUDA)
-                            MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        cuda_check(cudaMemcpy(h_send,d_send,message,cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
+                        MPI_Recv(h_recv,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv,h_recv,message,cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                        MPI_Send(send_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
 #else
-                            MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
+                        MPI_Send(send_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
 #endif
-                        }
-                    } else if (rank == partner_rank) {
-                        for (int w = 0; w < window; ++w) {
+                    } else {
 #if defined(USE_CUDA)
-                            MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        MPI_Recv(h_recv,message,MPI_CHAR,0,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv,h_recv,message,cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send,d_send,message,cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send,message,MPI_CHAR,0,0,MPI_COMM_WORLD);
 #else
-                            MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-#endif
-                        }
-                    }
-                } else { // BiBW warmup
-                    for (int w = 0; w < window; ++w) {
-#if defined(USE_CUDA)
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Sendrecv(h_send, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                     h_recv, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-#else
-                        MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                     recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        MPI_Recv(recv_buf,message,MPI_CHAR,0,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf,message,MPI_CHAR,0,0,MPI_COMM_WORLD);
 #endif
                     }
                 }
-            }
-            CALI_MARK_END(warmup_region);
+                CALI_MARK_END(warmup_region);
 
-            if (pair != MPI_COMM_NULL) MPI_Barrier(pair); // pair barrier (not WORLD)
-
-            // Measurements
-            double total_time = 0.0;
-            double min_t = std::numeric_limits<double>::infinity();
-            double max_t = 0.0;
-            int iters = 0;
-
-            CALI_MARK_BEGIN(region_label.c_str());
-
-            for (int b = 0; b < bursts; ++b) {
-                for (int i = 0; i < PING_PONG_LIMIT; i++) {
-                    if (mode == P2PMode::PingPong) {
-                        if (rank == 0) {
-#if defined(USE_CUDA)
-                            double start = MPI_Wtime();
-                            cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                            MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                            MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                            double end = MPI_Wtime();
-#else
-                            double start = MPI_Wtime();
-                            MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                            MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            double end = MPI_Wtime();
-#endif
-                            double dt = end - start;
-                            total_time += dt;
-                            if (dt < min_t) min_t = dt;
-                            if (dt > max_t) max_t = dt;
-                            ++iters;
-                        } else if (rank == partner_rank) {
-#if defined(USE_CUDA)
-                            MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                            cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                            MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
-#else
-                            MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
-#endif
-                        }
-                    } else if (mode == P2PMode::BW) {
-                        if (rank == 0) {
-#if defined(USE_CUDA)
-                            cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-#endif
-                            if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
-                            double t0 = MPI_Wtime();
-                            for (int w = 0; w < window; ++w) {
-#if defined(USE_CUDA)
-                                MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-#else
-                                MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-#endif
-                            }
-                            double dt = MPI_Wtime() - t0;
-                            total_time += dt;
-                            if (dt < min_t) min_t = dt;
-                            if (dt > max_t) max_t = dt;
-                            ++iters;
-                            if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
-                        } else if (rank == partner_rank) {
-                            if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
-                            for (int w = 0; w < window; ++w) {
-#if defined(USE_CUDA)
-                                MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                                cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-#else
-                                MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-#endif
-                            }
-                            if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
-                        }
-                    } else { // BiBW
-                        if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
+                CALI_MARK_BEGIN(region_label.c_str());
+                for (int i=0;i<PING_PONG_LIMIT;i++) {
+                    if (rank==0) {
                         double t0 = MPI_Wtime();
-                        for (int w = 0; w < window; ++w) {
 #if defined(USE_CUDA)
-                            cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                            MPI_Sendrecv(h_send, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                         h_recv, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                         MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send,d_send,message,cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
+                        MPI_Recv(h_recv,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv,h_recv,message,cudaMemcpyHostToDevice));
 #else
-                            MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                         recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                         MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf,message,MPI_CHAR,partner_rank,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
 #endif
-                        }
                         double dt = MPI_Wtime() - t0;
-                        double max_dt = 0.0;
-                        if (pair != MPI_COMM_NULL)
-                            MPI_Allreduce(&dt, &max_dt, 1, MPI_DOUBLE, MPI_MAX, pair);
-                        if (rank == 0) {
-                            total_time += max_dt;
-                            if (max_dt < min_t) min_t = max_dt;
-                            if (max_dt > max_t) max_t = max_dt;
-                            ++iters;
-                        }
-                        if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
+                        total_time += dt;
+                        if (dt<min_rtt) min_rtt=dt;
+                        if (dt>max_rtt) max_rtt=dt;
+                        ++iters;
+                    } else {
+#if defined(USE_CUDA)
+                        MPI_Recv(h_recv,message,MPI_CHAR,0,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv,h_recv,message,cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send,d_send,message,cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send,message,MPI_CHAR,0,0,MPI_COMM_WORLD);
+#else
+                        MPI_Recv(recv_buf,message,MPI_CHAR,0,0,MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf,message,MPI_CHAR,0,0,MPI_COMM_WORLD);
+#endif
                     }
-                } // iterations
+                }
+                CALI_MARK_END(region_label.c_str());
 
-                if (burst_sleep_ms > 0) usleep((useconds_t)burst_sleep_ms * 1000);
-            } // bursts
-
-            if (rank == 0) {
-                if (mode == P2PMode::PingPong) {
-                    double avg_rtt = (iters > 0) ? total_time / iters : 0.0;
+                if (rank==0) {
+                    double avg_rtt = iters ? total_time / iters : 0.0;
 #if defined(USE_CALIPER)
                     cali_set_string(comm_phase_attr, "pingpong");
                     cali_set_double(pp_avg_time_sec_attr, avg_rtt);
-                    cali_set_double(pp_max_time_sec_attr, max_t);
-                    cali_set_double(pp_min_time_sec_attr, min_t);
+                    cali_set_double(pp_max_time_sec_attr, max_rtt);
+                    cali_set_double(pp_min_time_sec_attr, min_rtt);
 #endif
-                    double avg_latency_us = (avg_rtt * 1e6) / 2.0;
-                    double min_latency_us = (min_t * 1e6) / 2.0;
-                    double max_latency_us = (max_t * 1e6) / 2.0;
-                    printf("[PINGPONG] RTT avg=%.6f s min=%.6f s max=%.6f s | latency(one-way) avg=%.1f us min=%.1f us max=%.1f us\n",
-                           avg_rtt, min_t, max_t, avg_latency_us, min_latency_us, max_latency_us);
-                } else if (mode == P2PMode::BW) {
-                    double bytes_per_iter = (double)window * (double)message;
-                    double avg_t = (iters > 0) ? total_time / iters : 0.0;
-                    double avg_MBps = (avg_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / avg_t : 0.0;
-                    double avg_Gbps = (avg_t > 0) ? (bytes_per_iter * 8.0 / 1e9) / avg_t : 0.0;
-                    double min_MBps = (max_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / max_t : 0.0;
-                    double max_MBps = (min_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / min_t : 0.0;
-                    printf("[BW] window=%d  per-iter-bytes=%.0f  time avg=%.6f s (min=%.6f, max=%.6f)\n",
-                           window, bytes_per_iter, avg_t, min_t, max_t);
-                    printf("     bandwidth avg=%.2f MB/s (%.2f Gb/s) | min=%.2f MB/s | max=%.2f MB/s\n",
-                           avg_MBps, avg_Gbps, min_MBps, max_MBps);
-                } else { // BiBW
-                    double bytes_per_iter = (double)window * (double)message;
-                    double avg_t = (iters > 0) ? total_time / iters : 0.0;
-                    double avg_MBps_each = (avg_t > 0) ? (bytes_per_iter / (1024.0*1024.0)) / avg_t : 0.0;
-                    double avg_Gbps_each = (avg_t > 0) ? (bytes_per_iter * 8.0 / 1e9) / avg_t : 0.0;
-                    printf("[BIBW] window=%d per-iter-bytes(each dir)=%.0f time avg=%.6f s (min=%.6f, max=%.6f)\n",
-                           window, bytes_per_iter, avg_t, min_t, max_t);
-                    printf("       bandwidth each-dir avg=%.2f MB/s (%.2f Gb/s); aggregate≈%.2f MB/s\n",
-                           avg_MBps_each, avg_Gbps_each, 2.0*avg_MBps_each);
+                    double avg_latency_us = (avg_rtt*1e6)/2.0;
+                    double min_latency_us = (min_rtt*1e6)/2.0;
+                    double max_latency_us = (max_rtt*1e6)/2.0;
+                    printf("[PINGPONG] msg=%d  RTT avg=%.6f s min=%.6f s max=%.6f s | latency(one-way) avg=%.1f us min=%.1f us max=%.1f us\n",
+                           message, avg_rtt, min_rtt, max_rtt, avg_latency_us, min_latency_us, max_latency_us);
                 }
-            }
-            CALI_MARK_END(region_label.c_str());
 
 #if defined(USE_HIP)
-            hipFree(send_buf); hipFree(recv_buf);
+                hipFree(send_buf); hipFree(recv_buf);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFreeHost(h_send)); cuda_check(cudaFreeHost(h_recv));
+                cuda_check(cudaFree(d_send));     cuda_check(cudaFree(d_recv));
+#else
+                free(send_buf); free(recv_buf);
+#endif
+                MPI_Barrier(MPI_COMM_WORLD);
+            } // partners
+        } // end pingpong
+
+        // ---------------- ALLTOALL (selected) ----------------
+        if (op == OpKind::Alltoall) {
+            size_t count_per_rank = (size_t)message;
+            size_t total_bytes = count_per_rank * (size_t)size;
+            int warmup = 1;
+            double total=0.0, min_t=std::numeric_limits<double>::infinity(), max_t=0.0;
+            int iters=0;
+
+#if defined(USE_HIP)
+            char *d_send,*d_recv; hipMalloc((void**)&d_send,total_bytes); hipMalloc((void**)&d_recv,total_bytes);
+            hipMemset(d_send,'a',total_bytes); hipMemset(d_recv,0,total_bytes);
+            char *h_send=(char*)malloc(total_bytes), *h_recv=(char*)malloc(total_bytes);
+            memset(h_send,'a',total_bytes); memset(h_recv,0,total_bytes);
+#elif defined(USE_CUDA)
+            int dev_count=0; cuda_check(cudaGetDeviceCount(&dev_count));
+            cuda_check(cudaSetDevice(rank % (dev_count>0?dev_count:1)));
+            char *d_send=nullptr,*d_recv=nullptr; cuda_check(cudaMalloc((void**)&d_send,total_bytes));
+            cuda_check(cudaMalloc((void**)&d_recv,total_bytes));
+            cuda_check(cudaMemset(d_send,'a',total_bytes)); cuda_check(cudaMemset(d_recv,0,total_bytes));
+            char *h_send=nullptr,*h_recv=nullptr; cuda_check(cudaMallocHost((void**)&h_send,total_bytes));
+            cuda_check(cudaMallocHost((void**)&h_recv,total_bytes));
+            memset(h_send,'a',total_bytes); memset(h_recv,0,total_bytes);
+#else
+            char *sendbuf=(char*)malloc(total_bytes), *recvbuf=(char*)malloc(total_bytes);
+            memset(sendbuf,'b',total_bytes); memset(recvbuf,0,total_bytes);
+#endif
+
+            CALI_MARK_BEGIN(warmup_region_aa);
+            for (int i=0;i<warmup;i++) {
+#if defined(USE_CUDA)
+                cuda_check(cudaMemcpy(h_send,d_send,total_bytes,cudaMemcpyDeviceToHost));
+                MPI_Alltoall(h_send,(int)count_per_rank,MPI_CHAR,h_recv,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
+                cuda_check(cudaMemcpy(d_recv,h_recv,total_bytes,cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                hipMemcpy(h_send,d_send,total_bytes,hipMemcpyDeviceToHost);
+                MPI_Alltoall(h_send,(int)count_per_rank,MPI_CHAR,h_recv,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
+                hipMemcpy(d_recv,h_recv,total_bytes,hipMemcpyHostToDevice);
+#else
+                MPI_Alltoall(sendbuf,(int)count_per_rank,MPI_CHAR,recvbuf,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
+#endif
+            }
+            CALI_MARK_END(warmup_region_aa);
+
+            CALI_MARK_BEGIN("Alltoall");
+            for (int it=0; it<PING_PONG_LIMIT; ++it) {
+                MPI_Barrier(MPI_COMM_WORLD);
+                double t0 = MPI_Wtime();
+#if defined(USE_CUDA)
+                cuda_check(cudaMemcpy(h_send,d_send,total_bytes,cudaMemcpyDeviceToHost));
+                MPI_Alltoall(h_send,(int)count_per_rank,MPI_CHAR,h_recv,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
+                cuda_check(cudaMemcpy(d_recv,h_recv,total_bytes,cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                hipMemcpy(h_send,d_send,total_bytes,hipMemcpyDeviceToHost);
+                MPI_Alltoall(h_send,(int)count_per_rank,MPI_CHAR,h_recv,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
+                hipMemcpy(d_recv,h_recv,total_bytes,hipMemcpyHostToDevice);
+#else
+                MPI_Alltoall(sendbuf,(int)count_per_rank,MPI_CHAR,recvbuf,(int)count_per_rank,MPI_CHAR,MPI_COMM_WORLD);
+#endif
+                double dt = MPI_Wtime()-t0;
+                double mx=0; MPI_Reduce(&dt,&mx,1,MPI_DOUBLE,MPI_MAX,0,MPI_COMM_WORLD);
+                if (rank==0) {
+                    total+=mx; if (dt<min_t) min_t=dt; if (dt>max_t) max_t=dt; ++iters;
+                }
+            }
+            CALI_MARK_END("Alltoall");
+
+            if (rank==0) {
+                double avg = iters? total/iters:0.0;
+#if defined(USE_CALIPER)
+                cali_set_string(comm_phase_attr,"alltoall");
+                cali_set_double(aa_avg_time_sec_attr,avg);
+                cali_set_double(aa_max_time_sec_attr,max_t);
+                cali_set_double(aa_min_time_sec_attr,min_t);
+#endif
+                printf("[ALLTOALL] msg/rank=%d  avg=%.6f s  min=%.6f s  max=%.6f s\n", message, avg, min_t, max_t);
+            }
+
+#if defined(USE_HIP)
+            free(h_send); free(h_recv); hipFree(d_send); hipFree(d_recv);
 #elif defined(USE_CUDA)
             cuda_check(cudaFreeHost(h_send)); cuda_check(cudaFreeHost(h_recv));
-            cuda_check(cudaFree(d_send));     cuda_check(cudaFree(d_recv));
+            cuda_check(cudaFree(d_send)); cuda_check(cudaFree(d_recv));
 #else
-            free(send_buf); free(recv_buf);
+            free(sendbuf); free(recvbuf);
 #endif
-
-            if (pair != MPI_COMM_NULL) MPI_Comm_free(&pair);
-        } // end P2P
-
-        // keep everyone aligned before starting collectives
-        MPI_Barrier(MPI_COMM_WORLD);
-
-        // ------------------------- ALLTOALL (SUBCOMMS) -------------------------
-        if (op == OpKind::Alltoall) for (int active_size : buckets) {
-            std::string region_label = "Alltoall_" + std::to_string(active_size);
-            MPI_Comm sub = make_prefix_subcomm(active_size);
-            int sub_rank=-1, sub_size=0;
-            if (sub != MPI_COMM_NULL) { MPI_Comm_rank(sub,&sub_rank); MPI_Comm_size(sub,&sub_size); }
-
-            size_t aa_bytes_per_rank = static_cast<size_t>(message);
-            size_t aa_total_bytes = aa_bytes_per_rank * static_cast<size_t>((sub==MPI_COMM_NULL)?0:sub_size);
-            int warmup = 1;
-            double alltoall_total_time = 0.0;
-            double min_rtt = std::numeric_limits<double>::infinity();
-            double max_rtt = 0.0;
-            int iters = 0;
-
-            if (sub != MPI_COMM_NULL) {
-#if defined(USE_HIP)
-                char *aa_send_dev; char *aa_recv_dev;
-                hipMalloc((void**)&aa_send_dev, aa_total_bytes);
-                hipMalloc((void**)&aa_recv_dev, aa_total_bytes);
-                hipMemset(aa_send_dev, 'a', aa_total_bytes);
-                hipMemset(aa_recv_dev, 0,   aa_total_bytes);
-                char *aa_send_host = (char*) malloc(aa_total_bytes);
-                char *aa_recv_host = (char*) malloc(aa_total_bytes);
-                memset(aa_send_host, 'a', aa_total_bytes);
-                memset(aa_recv_host, 0,   aa_total_bytes);
-#elif defined(USE_CUDA)
-                int a_dev_count=0; cuda_check(cudaGetDeviceCount(&a_dev_count));
-                cuda_check(cudaSetDevice(rank % (a_dev_count>0 ? a_dev_count : 1)));
-                char *ad_send=nullptr, *ad_recv=nullptr;
-                cuda_check(cudaMalloc((void**)&ad_send, aa_total_bytes));
-                cuda_check(cudaMalloc((void**)&ad_recv, aa_total_bytes));
-                cuda_check(cudaMemset(ad_send,'a',aa_total_bytes));
-                cuda_check(cudaMemset(ad_recv,0,  aa_total_bytes));
-                char *ah_send=nullptr, *ah_recv=nullptr;
-                cuda_check(cudaMallocHost((void**)&ah_send, aa_total_bytes));
-                cuda_check(cudaMallocHost((void**)&ah_recv, aa_total_bytes));
-                memset(ah_send,'a',aa_total_bytes);
-                memset(ah_recv,0,  aa_total_bytes);
-#else
-                char *aa_send = (char*) malloc(aa_total_bytes);
-                char *aa_recv = (char*) malloc(aa_total_bytes);
-                memset(aa_send, 'b', aa_total_bytes);
-                memset(aa_recv,  0, aa_total_bytes);
-#endif
-
-                CALI_MARK_BEGIN(warmup_region_aa);
-                for (int i = 0; i < warmup; i++) {
-#if defined(USE_HIP)
-                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
-                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR,
-                                 aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, sub);
-                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
-#elif defined(USE_CUDA)
-                    cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
-                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR,
-                                 ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
-                    cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
-#else
-                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR,
-                                 aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
-#endif
-                }
-                CALI_MARK_END(warmup_region_aa);
-
-                CALI_MARK_BEGIN(region_label.c_str());
-                for (int b = 0; b < bursts; ++b) {
-                    for (int it = 0; it < PING_PONG_LIMIT; ++it) {
-                        MPI_Barrier(sub);
-                        double t0 = MPI_Wtime();
-#if defined(USE_HIP)
-                        hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
-                        MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR,
-                                     aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, sub);
-                        hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
-#elif defined(USE_CUDA)
-                        cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
-                        MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR,
-                                     ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
-                        cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
-#else
-                        MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR,
-                                     aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, sub);
-#endif
-                        double dt = MPI_Wtime() - t0;
-                        double iter_max = 0.0;
-                        MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, sub);
-                        if (sub_rank == 0) {
-                            alltoall_total_time += iter_max;
-                            if (dt < min_rtt) min_rtt = dt;
-                            if (dt > max_rtt) max_rtt = dt;
-                            ++iters;
-                        }
-                    }
-                    MPI_Barrier(sub);
-                    if (burst_sleep_ms > 0) usleep((useconds_t)burst_sleep_ms * 1000);
-                }
-                CALI_MARK_END(region_label.c_str());
-
-                if (sub_rank == 0) {
-                    double avg_rtt = (iters > 0) ? alltoall_total_time / iters : 0.0;
-#if defined(USE_CALIPER)
-                    cali_set_string(comm_phase_attr, "alltoall");
-                    cali_set_double(aa_avg_time_sec_attr, avg_rtt);
-                    cali_set_double(aa_max_time_sec_attr, max_rtt);
-                    cali_set_double(aa_min_time_sec_attr, min_rtt);
-#endif
-                    printf("[ALLTOALL %d] avg=%.6f s min=%.6f s max=%.6f s\n",
-                           active_size, avg_rtt, min_rtt, max_rtt);
-                }
-
-#if defined(USE_HIP)
-                free(aa_send_host); free(aa_recv_host);
-                hipFree(aa_send_dev); hipFree(aa_recv_dev);
-#elif defined(USE_CUDA)
-                cuda_check(cudaFreeHost(ah_send)); cuda_check(cudaFreeHost(ah_recv));
-                cuda_check(cudaFree(ad_send)); cuda_check(cudaFree(ad_recv));
-#else
-                free(aa_send); free(aa_recv);
-#endif
-            }
-            if (sub != MPI_COMM_NULL) MPI_Comm_free(&sub);
             MPI_Barrier(MPI_COMM_WORLD);
         }
 
-        // ------------------------- REDUCE (SUBCOMMS) -------------------------
-        if (op == OpKind::Reduce) for (int active_size : buckets) {
-            std::string region_label = "Reduce_" + std::to_string(active_size);
-            MPI_Comm sub = make_prefix_subcomm(active_size);
-            int sub_rank=-1, sub_size=0;
-            if (sub != MPI_COMM_NULL) { MPI_Comm_rank(sub,&sub_rank); MPI_Comm_size(sub,&sub_size); }
+        // ---------------- REDUCE (selected) ----------------
+        if (op == OpKind::Reduce) {
+            size_t count = (size_t)message;
+            if (count > INT_MAX) { if(rank==0) fprintf(stderr,"Reduce count too large\n"); MPI_Abort(MPI_COMM_WORLD,3); }
+            int warmup=1; double total=0, min_t=std::numeric_limits<double>::infinity(), max_t=0; int iters=0;
 
-            size_t red_count = static_cast<size_t>(message);
-            if (red_count > INT_MAX) {
-                if (rank == 0) fprintf(stderr, "Reduce count too large\n");
-                MPI_Abort(MPI_COMM_WORLD, 1);
+#if defined(USE_CUDA)
+            char *d_send=nullptr,*d_recv=nullptr; cuda_check(cudaMalloc((void**)&d_send,count)); cuda_check(cudaMalloc((void**)&d_recv,count));
+            cuda_check(cudaMemset(d_send,'r',count)); cuda_check(cudaMemset(d_recv,0,count));
+            char *h_send=nullptr,*h_recv=nullptr; cuda_check(cudaMallocHost((void**)&h_send,count)); cuda_check(cudaMallocHost((void**)&h_recv,count));
+            memset(h_send,'r',count); memset(h_recv,0,count);
+#elif defined(USE_HIP)
+            char *d_send=nullptr,*d_recv=nullptr; hipMalloc((void**)&d_send,count); hipMalloc((void**)&d_recv,count);
+            hipMemset(d_send,'r',count); hipMemset(d_recv,0,count);
+            char *h_send=(char*)malloc(count), *h_recv=(char*)malloc(count);
+            memset(h_send,'r',count); memset(h_recv,0,count);
+#else
+            char *sendbuf=(char*)malloc(count), *recvbuf=(char*)malloc(count);
+            memset(sendbuf,'r',count); memset(recvbuf,0,count);
+#endif
+
+            CALI_MARK_BEGIN(warmup_region_red);
+            for (int i=0;i<warmup;i++) {
+#if defined(USE_CUDA)
+                cuda_check(cudaMemcpy(h_send,d_send,count,cudaMemcpyDeviceToHost));
+                MPI_Reduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
+                cuda_check(cudaMemcpy(d_recv,h_recv,count,cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                hipMemcpy(h_send,d_send,count,hipMemcpyDeviceToHost);
+                MPI_Reduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
+                hipMemcpy(d_recv,h_recv,count,hipMemcpyHostToDevice);
+#else
+                MPI_Reduce(sendbuf,recvbuf,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
+#endif
             }
-            int warmup = 1;
-            double red_total_time = 0.0;
-            double min_rtt = std::numeric_limits<double>::infinity();
-            double max_rtt = 0.0;
-            int iters = 0;
+            CALI_MARK_END(warmup_region_red);
 
-            if (sub != MPI_COMM_NULL) {
+            CALI_MARK_BEGIN("Reduce");
+            for (int i=0;i<PING_PONG_LIMIT;i++) {
+                MPI_Barrier(MPI_COMM_WORLD);
+                double t0 = MPI_Wtime();
 #if defined(USE_CUDA)
-                char *rd_d_send=nullptr, *rd_d_recv=nullptr;
-                cuda_check(cudaMalloc((void**)&rd_d_send, red_count));
-                cuda_check(cudaMalloc((void**)&rd_d_recv, red_count));
-                cuda_check(cudaMemset(rd_d_send, 'r', red_count));
-                cuda_check(cudaMemset(rd_d_recv, 0,   red_count));
-                char *rd_h_send=nullptr, *rd_h_recv=nullptr;
-                cuda_check(cudaMallocHost((void**)&rd_h_send, red_count));
-                cuda_check(cudaMallocHost((void**)&rd_h_recv, red_count));
-                memset(rd_h_send, 'r', red_count);
-                memset(rd_h_recv, 0,   red_count);
+                cuda_check(cudaMemcpy(h_send,d_send,count,cudaMemcpyDeviceToHost));
+                MPI_Reduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
+                cuda_check(cudaMemcpy(d_recv,h_recv,count,cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-                char *rd_d_send=nullptr, *rd_d_recv=nullptr;
-                hipMalloc((void**)&rd_d_send, red_count);
-                hipMalloc((void**)&rd_d_recv, red_count);
-                hipMemset(rd_d_send, 'r', red_count);
-                hipMemset(rd_d_recv, 0,   red_count);
-                char *rd_h_send=(char*)malloc(red_count);
-                char *rd_h_recv=(char*)malloc(red_count);
-                memset(rd_h_send, 'r', red_count);
-                memset(rd_h_recv, 0,   red_count);
+                hipMemcpy(h_send,d_send,count,hipMemcpyDeviceToHost);
+                MPI_Reduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
+                hipMemcpy(d_recv,h_recv,count,hipMemcpyHostToDevice);
 #else
-                char *rd_send=(char*)malloc(red_count);
-                char *rd_recv=(char*)malloc(red_count);
-                memset(rd_send, 'r', red_count);
-                memset(rd_recv, 0,   red_count);
+                MPI_Reduce(sendbuf,recvbuf,(int)count,MPI_CHAR,MPI_SUM,0,MPI_COMM_WORLD);
 #endif
+                double dt = MPI_Wtime()-t0;
+                double mx=0; MPI_Reduce(&dt,&mx,1,MPI_DOUBLE,MPI_MAX,0,MPI_COMM_WORLD);
+                if (rank==0) { total+=mx; if (dt<min_t) min_t=dt; if (dt>max_t) max_t=dt; ++iters; }
+            }
+            CALI_MARK_END("Reduce");
 
-                CALI_MARK_BEGIN(warmup_region_red);
-                for (int i = 0; i < warmup; i++) {
-#if defined(USE_CUDA)
-                    cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
-                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
-                    cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
-                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
-                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
-#else
-                    MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
-#endif
-                }
-                CALI_MARK_END(warmup_region_red);
-
-                CALI_MARK_BEGIN(region_label.c_str());
-                for (int b = 0; b < bursts; ++b) {
-                    for (int i = 0; i < PING_PONG_LIMIT; i++) {
-                        MPI_Barrier(sub);
-                        double t0 = MPI_Wtime();
-#if defined(USE_CUDA)
-                        cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
-                        MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
-                        cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                        hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
-                        MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
-                        hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
-#else
-                        MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, sub);
-#endif
-                        double dt = MPI_Wtime() - t0;
-                        double iter_max = 0.0;
-                        MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, sub);
-                        if (sub_rank == 0) {
-                            red_total_time += iter_max;
-                            if (dt < min_rtt) min_rtt = dt;
-                            if (dt > max_rtt) max_rtt = dt;
-                            ++iters;
-                        }
-                    }
-                    MPI_Barrier(sub);
-                    if (burst_sleep_ms > 0) usleep((useconds_t)burst_sleep_ms * 1000);
-                }
-                CALI_MARK_END(region_label.c_str());
-
-                if (sub_rank == 0) {
-                    double avg_rtt = (iters > 0) ? red_total_time / iters : 0.0;
+            if (rank==0) {
+                double avg = iters? total/iters:0.0;
 #if defined(USE_CALIPER)
-                    cali_set_string(comm_phase_attr, "reduce");
-                    cali_set_double(red_avg_time_sec_attr, avg_rtt);
-                    cali_set_double(red_max_time_sec_attr, max_rtt);
-                    cali_set_double(red_min_time_sec_attr, min_rtt);
+                cali_set_string(comm_phase_attr,"reduce");
+                cali_set_double(red_avg_time_sec_attr,avg);
+                cali_set_double(red_max_time_sec_attr,max_t);
+                cali_set_double(red_min_time_sec_attr,min_t);
 #endif
-                    printf("[REDUCE %d] avg=%.6f s min=%.6f s max=%.6f s\n",
-                           active_size, avg_rtt, min_rtt, max_rtt);
-                }
-
-#if defined(USE_HIP)
-                free(rd_h_send); free(rd_h_recv);
-                hipFree(rd_d_send); hipFree(rd_d_recv);
-#elif defined(USE_CUDA)
-                cuda_check(cudaFreeHost(rd_h_send));
-                cuda_check(cudaFreeHost(rd_h_recv));
-                cuda_check(cudaFree(rd_d_send));
-                cuda_check(cudaFree(rd_d_recv));
-#else
-                free(rd_send); free(rd_recv);
-#endif
+                printf("[REDUCE] msg=%d  avg=%.6f s  min=%.6f s  max=%.6f s\n", message, avg, min_t, max_t);
             }
-            if (sub != MPI_COMM_NULL) MPI_Comm_free(&sub);
 
+#if defined(USE_CUDA)
+            cuda_check(cudaFreeHost(h_send)); cuda_check(cudaFreeHost(h_recv));
+            cuda_check(cudaFree(d_send)); cuda_check(cudaFree(d_recv));
+#elif defined(USE_HIP)
+            free(h_send); free(h_recv); hipFree(d_send); hipFree(d_recv);
+#else
+            free(sendbuf); free(recvbuf);
+#endif
             MPI_Barrier(MPI_COMM_WORLD);
         }
 
-        // ------------------------- ALLREDUCE (SUBCOMMS) -------------------------
-        if (op == OpKind::Allreduce) for (int active_size : buckets) {
-            std::string region_label = "Allreduce_" + std::to_string(active_size);
-            MPI_Comm sub = make_prefix_subcomm(active_size);
-            int sub_rank=-1, sub_size=0;
-            if (sub != MPI_COMM_NULL) { MPI_Comm_rank(sub,&sub_rank); MPI_Comm_size(sub,&sub_size); }
+        // ---------------- ALLREDUCE (selected) ----------------
+        if (op == OpKind::Allreduce) {
+            size_t count = (size_t)message;
+            if (count > INT_MAX) { if(rank==0) fprintf(stderr,"Allreduce count too large\n"); MPI_Abort(MPI_COMM_WORLD,4); }
+            int warmup=1; double total=0, min_t=std::numeric_limits<double>::infinity(), max_t=0; int iters=0;
 
-            size_t ar_count = static_cast<size_t>(message);
-            if (ar_count > INT_MAX) {
-                if (rank == 0) fprintf(stderr, "Allreduce count too large\n");
-                MPI_Abort(MPI_COMM_WORLD, 1);
+#if defined(USE_CUDA)
+            char *d_send=nullptr,*d_recv=nullptr; cuda_check(cudaMalloc((void**)&d_send,count)); cuda_check(cudaMalloc((void**)&d_recv,count));
+            cuda_check(cudaMemset(d_send,'a',count)); cuda_check(cudaMemset(d_recv,0,count));
+            char *h_send=nullptr,*h_recv=nullptr; cuda_check(cudaMallocHost((void**)&h_send,count)); cuda_check(cudaMallocHost((void**)&h_recv,count));
+            memset(h_send,'a',count); memset(h_recv,0,count);
+#elif defined(USE_HIP)
+            char *d_send=nullptr,*d_recv=nullptr; hipMalloc((void**)&d_send,count); hipMalloc((void**)&d_recv,count);
+            hipMemset(d_send,'a',count); hipMemset(d_recv,0,count);
+            char *h_send=(char*)malloc(count), *h_recv=(char*)malloc(count);
+            memset(h_send,'a',count); memset(h_recv,0,count);
+#else
+            char *sendbuf=(char*)malloc(count), *recvbuf=(char*)malloc(count);
+            memset(sendbuf,'a',count); memset(recvbuf,0,count);
+#endif
+
+            CALI_MARK_BEGIN(warmup_region_ar);
+            for (int i=0;i<warmup;i++) {
+#if defined(USE_CUDA)
+                cuda_check(cudaMemcpy(h_send,d_send,count,cudaMemcpyDeviceToHost));
+                MPI_Allreduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
+                cuda_check(cudaMemcpy(d_recv,h_recv,count,cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                hipMemcpy(h_send,d_send,count,hipMemcpyDeviceToHost);
+                MPI_Allreduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
+                hipMemcpy(d_recv,h_recv,count,hipMemcpyHostToDevice);
+#else
+                MPI_Allreduce(sendbuf,recvbuf,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
+#endif
             }
-            int warmup = 1;
-            double ar_total_time = 0.0;
-            double min_rtt = std::numeric_limits<double>::infinity();
-            double max_rtt = 0.0;
-            int iters = 0;
+            CALI_MARK_END(warmup_region_ar);
 
-            if (sub != MPI_COMM_NULL) {
+            CALI_MARK_BEGIN("Allreduce");
+            for (int i=0;i<PING_PONG_LIMIT;i++) {
+                MPI_Barrier(MPI_COMM_WORLD);
+                double t0 = MPI_Wtime();
 #if defined(USE_CUDA)
-                char *ar_d_send=nullptr; char *ar_d_recv=nullptr;
-                cuda_check(cudaMalloc((void**)&ar_d_send, ar_count));
-                cuda_check(cudaMalloc((void**)&ar_d_recv, ar_count));
-                cuda_check(cudaMemset(ar_d_send, 'a', ar_count));
-                cuda_check(cudaMemset(ar_d_recv, 0,   ar_count));
-                char *ar_h_send=nullptr; char *ar_h_recv=nullptr;
-                cuda_check(cudaMallocHost((void**)&ar_h_send, ar_count));
-                cuda_check(cudaMallocHost((void**)&ar_h_recv, ar_count));
-                memset(ar_h_send, 'a', ar_count);
-                memset(ar_h_recv, 0,   ar_count);
+                cuda_check(cudaMemcpy(h_send,d_send,count,cudaMemcpyDeviceToHost));
+                MPI_Allreduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
+                cuda_check(cudaMemcpy(d_recv,h_recv,count,cudaMemcpyHostToDevice));
 #elif defined(USE_HIP)
-                char *ar_d_send=nullptr; char *ar_d_recv=nullptr;
-                hipMalloc((void**)&ar_d_send, ar_count);
-                hipMalloc((void**)&ar_d_recv, ar_count);
-                hipMemset(ar_d_send, 'a', ar_count);
-                hipMemset(ar_d_recv, 0,   ar_count);
-                char *ar_h_send=(char*)malloc(ar_count);
-                char *ar_h_recv=(char*)malloc(ar_count);
-                memset(ar_h_send, 'a', ar_count);
-                memset(ar_h_recv, 0,   ar_count);
+                hipMemcpy(h_send,d_send,count,hipMemcpyDeviceToHost);
+                MPI_Allreduce(h_send,h_recv,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
+                hipMemcpy(d_recv,h_recv,count,hipMemcpyHostToDevice);
 #else
-                char *ar_send=(char*)malloc(ar_count);
-                char *ar_recv=(char*)malloc(ar_count);
-                memset(ar_send, 'a', ar_count);
-                memset(ar_recv, 0,   ar_count);
+                MPI_Allreduce(sendbuf,recvbuf,(int)count,MPI_CHAR,MPI_SUM,MPI_COMM_WORLD);
 #endif
+                double dt = MPI_Wtime()-t0;
+                double mx=0; MPI_Allreduce(&dt,&mx,1,MPI_DOUBLE,MPI_MAX,MPI_COMM_WORLD);
+                if (rank==0) { total+=mx; if (dt<min_t) min_t=dt; if (dt>max_t) max_t=dt; ++iters; }
+            }
+            CALI_MARK_END("Allreduce");
 
-                CALI_MARK_BEGIN(warmup_region_ar);
-                for (int i = 0; i < warmup; i++) {
-#if defined(USE_CUDA)
-                    cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
-                    cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
-                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
-                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
-#else
-                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
-#endif
-                }
-                CALI_MARK_END(warmup_region_ar);
-
-                CALI_MARK_BEGIN(region_label.c_str());
-                for (int b = 0; b < bursts; ++b) {
-                    for (int i = 0; i < PING_PONG_LIMIT; i++) {
-                        MPI_Barrier(sub);
-                        double t0 = MPI_Wtime();
-#if defined(USE_CUDA)
-                        cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
-                        MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
-                        cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                        hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
-                        MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
-                        hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
-#else
-                        MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, sub);
-#endif
-                        double dt = MPI_Wtime() - t0;
-                        double iter_max = 0.0;
-                        MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, sub);
-                        if (sub_rank == 0) {
-                            ar_total_time += iter_max;
-                            if (dt < min_rtt) min_rtt = dt;
-                            if (dt > max_rtt) max_rtt = dt;
-                            ++iters;
-                        }
-                    }
-                    MPI_Barrier(sub);
-                    if (burst_sleep_ms > 0) usleep((useconds_t)burst_sleep_ms * 1000);
-                }
-                CALI_MARK_END(region_label.c_str());
-
-                if (sub_rank == 0) {
-                    double avg_rtt = (iters > 0) ? ar_total_time / iters : 0.0;
+            if (rank==0) {
+                double avg = iters? total/iters:0.0;
 #if defined(USE_CALIPER)
-                    cali_set_string(comm_phase_attr, "allreduce");
-                    cali_set_double(ar_avg_time_sec_attr, avg_rtt);
-                    cali_set_double(ar_max_time_sec_attr, max_rtt);
-                    cali_set_double(ar_min_time_sec_attr, min_rtt);
+                cali_set_string(comm_phase_attr,"allreduce");
+                cali_set_double(ar_avg_time_sec_attr,avg);
+                cali_set_double(ar_max_time_sec_attr,max_t);
+                cali_set_double(ar_min_time_sec_attr,min_t);
 #endif
-                    printf("[ALLREDUCE %d] avg=%.6f s min=%.6f s max=%.6f s\n",
-                           active_size, avg_rtt, min_rtt, max_rtt);
-                }
-
-#if defined(USE_HIP)
-                free(ar_h_send); free(ar_h_recv);
-                hipFree(ar_d_send); hipFree(ar_d_recv);
-#elif defined(USE_CUDA)
-                cuda_check(cudaFreeHost(ar_h_send)); cuda_check(cudaFreeHost(ar_h_recv));
-                cuda_check(cudaFree(ar_d_send));     cuda_check(cudaFree(ar_d_recv));
-#else
-                free(ar_send); free(ar_recv);
-#endif
+                printf("[ALLREDUCE] msg=%d  avg=%.6f s  min=%.6f s  max=%.6f s\n", message, avg, min_t, max_t);
             }
-            if (sub != MPI_COMM_NULL) MPI_Comm_free(&sub);
 
+#if defined(USE_CUDA)
+            cuda_check(cudaFreeHost(h_send)); cuda_check(cudaFreeHost(h_recv));
+            cuda_check(cudaFree(d_send)); cuda_check(cudaFree(d_recv));
+#elif defined(USE_HIP)
+            free(h_send); free(h_recv); hipFree(d_send); hipFree(d_recv);
+#else
+            free(sendbuf); free(recvbuf);
+#endif
             MPI_Barrier(MPI_COMM_WORLD);
         }
 
 #if defined(USE_CALIPER)
         mgr[message].stop();
 #endif
-        MPI_Barrier(MPI_COMM_WORLD); // sync before next message size
-    }
+    } // message sweep
 
 #if defined(USE_CALIPER)
     if (rank == 0 && !all_comm_pairs.empty()) {
         adiak::value("all_comm_pairs", all_comm_pairs);
     }
-    for (auto &m : mgr) {
-        m.second.flush();
-    }
+    for (auto &m : mgr) m.second.flush();
 #endif
 
     MPI_Finalize();

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -15,7 +15,7 @@
 #include <limits>
 #include <assert.h>
 #include <limits.h>
-#include <random>   // <--- added
+#include <random>
 
 #if defined(USE_CALIPER)
 #include <caliper/cali.h>
@@ -171,7 +171,6 @@ build_pingpong_pairs(const std::string& region_label,
     return pairs;
 }
 
-
 int main(int argc, char **argv)
 {
     int rank, size;
@@ -196,6 +195,7 @@ int main(int argc, char **argv)
 #endif
 
     int PING_PONG_LIMIT = 10;
+    const int WINDOW_SIZE = 1; // OSU-style window exchange; no SINGLE/MULTIPLE modes
     int msg_size = 1;
     int n_nodes = 1;
     int sys_cores_per_socket = 1;
@@ -217,7 +217,6 @@ int main(int argc, char **argv)
         "[-O pingpong|alltoall|reduce|allreduce|all]\n"
         "Default: -O pingpong\n";
 
-    // add 'O:' to parse the selector
     while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:O:")) != -1)
     {
         switch (opt)
@@ -230,7 +229,7 @@ int main(int argc, char **argv)
                 PING_PONG_LIMIT = atoi(optarg);
                 break;
             case 'p':
-                // kept for compatibility; you can parse partners here if desired
+                // kept for compatibility; parse partners here if desired
                 break;
             case 'm':
                 msg_size = atoi(optarg);
@@ -459,7 +458,7 @@ int main(int argc, char **argv)
             {
                 std::string region_label = region_names[partner_rank];
 
-                // Build up to 4 pairs for this region
+                // Build up to N pairs for this region
                 std::vector<RankPair> pairs =
                     build_pingpong_pairs(region_label,
                                          size,
@@ -482,7 +481,6 @@ int main(int argc, char **argv)
 
                 int partner = my_partner[rank];
                 if (partner == MPI_PROC_NULL) {
-                    // This rank does not participate in this region's pingpong
                     continue;
                 }
 
@@ -509,6 +507,13 @@ int main(int argc, char **argv)
 
                 double total_time = 0.0;
                 int warmup = 1;
+
+                // OSU-style directional tags for this pair:
+                // lower rank receives TAG_A and sends TAG_B; higher rank receives TAG_B and sends TAG_A
+                const int TAG_A = 10;
+                const int TAG_B = 100;
+                const int my_recv_tag = (rank < partner) ? TAG_A : TAG_B;
+                const int my_send_tag = (rank < partner) ? TAG_B : TAG_A;
 
                 // ---------- buffer allocation ----------
 #if defined(USE_HIP)
@@ -554,18 +559,25 @@ int main(int argc, char **argv)
                 memset(h_recv, 0, message);
 
                 cuda_check(cudaMemcpy(d_send, h_send, message, cudaMemcpyHostToDevice));
-                cuda_check(cudaMemset(d_recv, 0, message));
+                cuda_check(cudaMemset(d_recv, 0, message);
 
 #else
-                const int iters_total = PING_PONG_LIMIT;
+                // MPI-only path: always per-window-slot buffers (no SINGLE/MULTIPLE behavior)
+                char *send_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
+                char *recv_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
 
-                std::vector<std::vector<char>> send_mat(iters_total, std::vector<char>(message));
-                std::vector<std::vector<char>> recv_mat(iters_total, std::vector<char>(message));
+                std::vector<char*> s_buf(WINDOW_SIZE);
+                std::vector<char*> r_buf(WINDOW_SIZE);
 
-                for (int it = 0; it < iters_total; ++it) {
-                    fill_with_random_pattern(send_mat[it].data(), (size_t)message);
-                    memset(recv_mat[it].data(), 0, (size_t)message);
+                for (int j = 0; j < WINDOW_SIZE; ++j) {
+                    s_buf[j] = send_flat + (size_t)j * (size_t)message;
+                    r_buf[j] = recv_flat + (size_t)j * (size_t)message;
+                    fill_with_random_pattern(s_buf[j], (size_t)message); // fill once
+                    memset(r_buf[j], 0, (size_t)message);
                 }
+
+                std::vector<MPI_Request> send_request(WINDOW_SIZE);
+                std::vector<MPI_Request> recv_request(WINDOW_SIZE);
 #endif
 
                 // ---------- warmup ----------
@@ -575,6 +587,7 @@ int main(int argc, char **argv)
                 for (int i = 0; i < warmup; i++)
                 {
 #if defined(USE_HIP)
+                    // keep your original HIP blocking order
                     if (rank < partner) {
                         MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                         MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
@@ -585,6 +598,7 @@ int main(int argc, char **argv)
                         MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #elif defined(USE_CUDA)
+                    // keep your original CUDA blocking order (staging through pinned host)
                     if (rank < partner) {
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
@@ -599,34 +613,33 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
-                    int it = i % iters_total;
-                    char* srow = send_mat[it].data();
-                    char* rrow = recv_mat[it].data();
-
-                    if (rank < partner) {
-                        MPI_Send(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                MPI_STATUS_IGNORE);
-                    } else {
-                        MPI_Recv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                MPI_STATUS_IGNORE);
-                        MPI_Send(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                    // OSU pattern: post all Irecvs, post all Isends, waitall sends, waitall recvs
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
+                                  MPI_COMM_WORLD, &recv_request[j]);
                     }
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
+                                  MPI_COMM_WORLD, &send_request[j]);
+                    }
+                    MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
 #endif
                 }
+
 #if defined(USE_CALIPER)
                 CALI_MARK_END(warmup_region);
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
 
-                // ---------- timed ping-pong (multiple pairs at once) ----------
+                // ---------- timed ping-pong ----------
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
-                MPI_Request rreq, sreq;
 
-                // One rank per pair records timings (the "lower" rank)
                 bool i_am_timing_rank = (rank < partner);
+
+                MPI_Barrier(MPI_COMM_WORLD);
 
                 for (int i = 0; i < PING_PONG_LIMIT; i++)
                 {
@@ -660,18 +673,16 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
-                    char* srow = send_mat[i].data();
-                    char* rrow = recv_mat[i].data();
-
-                    if (rank < partner) {
-                        MPI_Isend(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
-                        MPI_Irecv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &rreq);
-                    } else {
-                        MPI_Irecv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &rreq);
-                        MPI_Isend(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
+                                  MPI_COMM_WORLD, &recv_request[j]);
                     }
-                    MPI_Wait(&rreq, MPI_STATUS_IGNORE);
-                    MPI_Wait(&sreq, MPI_STATUS_IGNORE);
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
+                                  MPI_COMM_WORLD, &send_request[j]);
+                    }
+                    MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
 #endif
 
                     if (i_am_timing_rank) {
@@ -695,7 +706,6 @@ int main(int argc, char **argv)
                     cali_set_double(pp_min_time_sec_attr, min_rtt);
 #endif
 
-                    // Optional: print per-pair stats
                     printf("PINGPONG %s pair (%d,%d): avg=%g s, min=%g s, max=%g s\n",
                            region_label.c_str(), rank, partner,
                            avg_rtt, min_rtt, max_rtt);
@@ -715,8 +725,8 @@ int main(int argc, char **argv)
                 cuda_check(cudaFree(d_send));
                 cuda_check(cudaFree(d_recv));
 #else
-                // free(send_flat);
-                // free(recv_flat);
+                free(send_flat);
+                free(recv_flat);
 #endif
             } // end for (partner_rank : partners)
         }     // end if (PingPong || All)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -891,7 +891,7 @@ int main(int argc, char **argv)
                         cali_set_double(aa_avg_time_sec_attr, avg_rtt);
                         cali_set_double(aa_max_time_sec_attr, max_rtt);
                         cali_set_double(aa_min_time_sec_attr, min_rtt);
-                        printf("finished iteration: %d\n" &it);
+                        printf("finished iteration: %d\n", it);
                         fflush(stdout);
 #endif
                     }

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -881,7 +881,7 @@ int main(int argc, char **argv)
                     double dt = t1 - t0;
 
                     double iter_max = 0.0;
-                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD); //timing for the longest rank because collective operation not finished until every rank finishes
                     if (rank == 0)
                     {
                         alltoall_total_time += iter_max;

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -765,11 +765,34 @@ int main(int argc, char **argv)
             {
                 std::string region_label = region_names[partner_rank];
 
+                int ranks_in_region = partner_rank + 1;
+                int active = (rank < ranks_in_region);
+
+                MPI_Comm region_comm = MPI_COMM_NULL;
+                MPI_Comm_split(MPI_COMM_WORLD, active ? 0 : MPI_UNDEFINED, rank, &region_comm);
+
+                if (!active)
+                {
+                    MPI_Barrier(MPI_COMM_WORLD);
+                    continue;
+                }
+
+                int region_rank = 0;
+                int region_size = 0;
+                MPI_Comm_rank(region_comm, &region_rank);
+                MPI_Comm_size(region_comm, &region_size);
+
                 size_t aa_bytes_per_rank = static_cast<size_t>(message);
-                size_t aa_total_bytes = aa_bytes_per_rank * static_cast<size_t>(size);
+                size_t aa_total_bytes = aa_bytes_per_rank * static_cast<size_t>(region_size);
 
                 int warmup = 1;
                 double alltoall_total_time = 0.0;
+
+                if (region_rank == 0) {
+                    printf("\n--- Testing %s (ALLTOALL) with %d ranks ---\n", region_label.c_str(), region_size);
+                    printf("message=%d bytes, total buffer per rank=%zu bytes\n", message, aa_total_bytes);
+                    fflush(stdout);
+                }
 
                 // --- buffer allocation ---
 #if defined(USE_HIP)
@@ -834,15 +857,15 @@ int main(int argc, char **argv)
 #if defined(USE_HIP)
                     hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
                     hipDeviceSynchronize();
-                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
                     hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
                     hipDeviceSynchronize();
 #elif defined(USE_CUDA)
                     cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
-                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
                     cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
 #else
-                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
 #endif
                 }
 
@@ -860,29 +883,29 @@ int main(int argc, char **argv)
                 // --- timed alltoall ---
                 for (int it = 0; it < num_iterations; ++it)
                 {
-                    MPI_Barrier(MPI_COMM_WORLD);
+                    MPI_Barrier(region_comm);
 
                     double t0 = MPI_Wtime();
 
 #if defined(USE_HIP)
                     hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
-                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
                     hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
                     hipDeviceSynchronize();
 #elif defined(USE_CUDA)
                     cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
-                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
                     cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
 #else
-                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
 #endif
 
                     double t1 = MPI_Wtime();
                     double dt = t1 - t0;
 
                     double iter_max = 0.0;
-                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD); //timing for the longest rank because collective operation not finished until every rank finishes
-                    if (rank == 0)
+                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, region_comm); //timing for the longest rank because collective operation not finished until every rank finishes
+                    if (region_rank == 0)
                     {
                         alltoall_total_time += iter_max;
                         if(iter_max < min_rtt) min_rtt = iter_max;      //min & max not computing correctly on rank 0
@@ -923,6 +946,8 @@ int main(int argc, char **argv)
 #endif
                 printf("freed memory\n");
                 fflush(stdout);
+                MPI_Comm_free(&region_comm);        //free subcommunicator
+                MPI_Barrier(MPI_COMM_WORLD);
             }
         }
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -823,7 +823,8 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region_aa);
 #endif
-                printf("begin warmup");
+                printf("rank %d: begin warmup\n", rank);
+                fflush(stdout);
 
                 for (int i = 0; i < warmup; i++)
                 {
@@ -847,7 +848,8 @@ int main(int argc, char **argv)
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
 
-                printf("end warmup, begin timing");
+                printf("rank %d: end warmup, begin timing\n", rank);
+                fflush(stdout);
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
@@ -889,13 +891,16 @@ int main(int argc, char **argv)
                         cali_set_double(aa_avg_time_sec_attr, avg_rtt);
                         cali_set_double(aa_max_time_sec_attr, max_rtt);
                         cali_set_double(aa_min_time_sec_attr, min_rtt);
+                        printf("finished iteration: &d\n" &it);
+                        fflush(stdout);
 #endif
                     }
                 }
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
 #endif
-                printf("end timing");
+                printf("rank &d: end timing\n");
+                fflush(stdout);
 
 #if defined(USE_HIP)
                 free(aa_send_host);
@@ -911,7 +916,8 @@ int main(int argc, char **argv)
                 free(aa_send);
                 free(aa_recv);
 #endif
-                printf("freed memory");
+                printf("freed memory\n");
+                fflush(stdout);
             }
         }
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -823,7 +823,7 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region_aa);
 #endif
-                fprintf("begin warmup");
+                printf("begin warmup");
 
                 for (int i = 0; i < warmup; i++)
                 {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
     const char *warmup_region_aa = "warmup_aa";
     const char *warmup_region_red = "warmup_red";
     const char *warmup_region_ar = "warmup_ar";
-    int pingpong_num_pairs = 1;
+    int pingpong_num_pairs = 4;
 
     // ---- default to PingPong ----
     OpKind op = OpKind::PingPong;

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -15,6 +15,7 @@
 #include <limits>
 #include <assert.h>
 #include <limits.h>
+#include <random>   // <--- added
 
 #if defined(USE_CALIPER)
 #include <caliper/cali.h>
@@ -73,6 +74,25 @@ int extract_node_number(const char *hostname)
         }
     }
     return num;
+}
+
+// Fill buf[0..len-1] with a repeating random pattern of length 16.
+void fill_with_random_pattern(char* buf, size_t len)
+{
+    if (!buf || len == 0)
+        return;
+
+    static thread_local std::mt19937 gen(std::random_device{}());
+    std::uniform_int_distribution<int> dist(0, 25); // 'a'..'z'
+
+    char pattern[16];
+    for (int i = 0; i < 16; ++i) {
+        pattern[i] = static_cast<char>('a' + dist(gen));
+    }
+
+    for (size_t i = 0; i < len; ++i) {
+        buf[i] = pattern[i % 16];
+    }
 }
 
 int main(int argc, char **argv)
@@ -397,10 +417,17 @@ int main(int argc, char **argv)
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
 
-                hipError_t cuerr1 = hipMemset(send_buf, 'a', message);
-                assert(cuerr1 == hipSuccess);
+                // host pattern for HIP send buffer
+                {
+                    char* h_rand = (char*)malloc(message);
+                    fill_with_random_pattern(h_rand, (size_t)message);
+                    hipError_t cuerr1 = hipMemcpy(send_buf, h_rand, message, hipMemcpyHostToDevice);
+                    assert(cuerr1 == hipSuccess);
+                    free(h_rand);
+                }
                 hipError_t cuerr2 = hipMemset(recv_buf, 0, message);
                 assert(cuerr2 == hipSuccess);
+
 #elif defined(USE_CUDA)
                 int dev_count = 0;
                 cuda_check(cudaGetDeviceCount(&dev_count));
@@ -410,18 +437,21 @@ int main(int argc, char **argv)
                 char *d_recv = nullptr;
                 cuda_check(cudaMalloc((void**)&d_send, message));
                 cuda_check(cudaMalloc((void**)&d_recv, message));
-                cuda_check(cudaMemset(d_send, 'a', message));
-                cuda_check(cudaMemset(d_recv, 0, message));
 
                 char *h_send = nullptr, *h_recv = nullptr;
                 cuda_check(cudaMallocHost((void**)&h_send, message));
                 cuda_check(cudaMallocHost((void**)&h_recv, message));
-                memset(h_send, 'a', message);
+
+                fill_with_random_pattern(h_send, (size_t)message);
                 memset(h_recv, 0, message);
+
+                cuda_check(cudaMemcpy(d_send, h_send, message, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(d_recv, 0, message));
+
 #else
                 char *send_buf = (char *)malloc(message);
                 char *recv_buf = (char *)malloc(message);
-                memset(send_buf, 'a', message);
+                fill_with_random_pattern(send_buf, (size_t)message);
                 memset(recv_buf, 0, message);
 #endif
 
@@ -568,15 +598,15 @@ int main(int argc, char **argv)
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
 
-                hipError_t a_cuerr1 = hipMemset(aa_send_dev, 'a', aa_total_bytes);
+                char *aa_send_host = (char*) malloc(aa_total_bytes);
+                char *aa_recv_host = (char*) malloc(aa_total_bytes);
+                fill_with_random_pattern(aa_send_host, aa_total_bytes);
+                memset(aa_recv_host, 0, aa_total_bytes);
+
+                hipError_t a_cuerr1 = hipMemcpy(aa_send_dev, aa_send_host, aa_total_bytes, hipMemcpyHostToDevice);
                 assert(a_cuerr1 == hipSuccess);
                 hipError_t a_cuerr2 = hipMemset(aa_recv_dev, 0, aa_total_bytes);
                 assert(a_cuerr2 == hipSuccess);
-
-                char *aa_send_host = (char*) malloc(aa_total_bytes);
-                char *aa_recv_host = (char*) malloc(aa_total_bytes);
-                memset(aa_send_host, 'a', aa_total_bytes);
-                memset(aa_recv_host, 0, aa_total_bytes);
 
 #elif defined(USE_CUDA)
                 int a_dev_count = 0;
@@ -587,19 +617,22 @@ int main(int argc, char **argv)
                 char *ad_recv = nullptr;
                 cuda_check(cudaMalloc((void**)&ad_send, aa_total_bytes));
                 cuda_check(cudaMalloc((void**)&ad_recv, aa_total_bytes));
-                cuda_check(cudaMemset(ad_send, 'a', aa_total_bytes));
-                cuda_check(cudaMemset(ad_recv, 0, aa_total_bytes));
 
                 char *ah_send = nullptr;
                 char *ah_recv = nullptr;
                 cuda_check(cudaMallocHost((void**)&ah_send, aa_total_bytes));
                 cuda_check(cudaMallocHost((void**)&ah_recv, aa_total_bytes));
-                memset(ah_send, 'a', aa_total_bytes);
+
+                fill_with_random_pattern(ah_send, aa_total_bytes);
                 memset(ah_recv, 0, aa_total_bytes);
+
+                cuda_check(cudaMemcpy(ad_send, ah_send, aa_total_bytes, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(ad_recv, 0, aa_total_bytes));
+
 #else
                 char *aa_send = (char*) malloc(aa_total_bytes);
                 char *aa_recv = (char*) malloc(aa_total_bytes);
-                memset(aa_send, 'b', aa_total_bytes);
+                fill_with_random_pattern(aa_send, aa_total_bytes);
                 memset(aa_recv,  0, aa_total_bytes);
 #endif
 
@@ -610,7 +643,7 @@ int main(int argc, char **argv)
                 for (int i = 0; i < warmup; i++)
                 {
 #if defined(USE_HIP)
-                    hipMemcpy(aa_send_dev, aa_send_host, aa_total_bytes, hipMemcpyHostToDevice);
+                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
                     hipDeviceSynchronize();
                     MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
                     hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
@@ -718,15 +751,18 @@ int main(int argc, char **argv)
 
                 cuda_check(cudaMalloc((void**)&rd_d_send, red_count));
                 cuda_check(cudaMalloc((void**)&rd_d_recv, red_count));
-                cuda_check(cudaMemset(rd_d_send, 'r', red_count));
-                cuda_check(cudaMemset(rd_d_recv, 0,   red_count));
 
                 char *rd_h_send=nullptr;
                 char *rd_h_recv=nullptr;
                 cuda_check(cudaMallocHost((void**)&rd_h_send, red_count));
                 cuda_check(cudaMallocHost((void**)&rd_h_recv, red_count));
-                memset(rd_h_send, 'r', red_count);
+
+                fill_with_random_pattern(rd_h_send, red_count);
                 memset(rd_h_recv, 0,   red_count);
+
+                cuda_check(cudaMemcpy(rd_d_send, rd_h_send, red_count, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(rd_d_recv, 0,   red_count));
+
 #elif defined(USE_HIP)
                 char *rd_d_send=nullptr;
                 char *rd_d_recv=nullptr;
@@ -739,19 +775,19 @@ int main(int argc, char **argv)
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
 
-                hipError_t a_cuerr1 = hipMemset(rd_d_send, 'a', red_count);
+                char *rd_h_send = (char*)malloc(red_count);
+                char *rd_h_recv = (char*)malloc(red_count);
+                fill_with_random_pattern(rd_h_send, red_count);
+                memset(rd_h_recv, 0,   red_count);
+
+                hipError_t a_cuerr1 = hipMemcpy(rd_d_send, rd_h_send, red_count, hipMemcpyHostToDevice);
                 assert(a_cuerr1 == hipSuccess);
                 hipError_t a_cuerr2 = hipMemset(rd_d_recv, 0, red_count);
                 assert(a_cuerr2 == hipSuccess);
-
-                char *rd_h_send = (char*)malloc(red_count);
-                char *rd_h_recv = (char*)malloc(red_count);
-                memset(rd_h_send, 'r', red_count);
-                memset(rd_h_recv, 0,   red_count);
 #else
                 char *rd_send = (char*)malloc(red_count);
                 char *rd_recv = (char*)malloc(red_count);
-                memset(rd_send, 'r', red_count);
+                fill_with_random_pattern(rd_send, red_count);
                 memset(rd_recv, 0,   red_count);
 #endif
 
@@ -860,15 +896,18 @@ int main(int argc, char **argv)
                 char *ar_d_recv=nullptr;
                 cuda_check(cudaMalloc((void**)&ar_d_send, ar_count));
                 cuda_check(cudaMalloc((void**)&ar_d_recv, ar_count));
-                cuda_check(cudaMemset(ar_d_send, 'a', ar_count));
-                cuda_check(cudaMemset(ar_d_recv, 0,   ar_count));
 
                 char *ar_h_send=nullptr;
                 char *ar_h_recv=nullptr;
                 cuda_check(cudaMallocHost((void**)&ar_h_send, ar_count));
                 cuda_check(cudaMallocHost((void**)&ar_h_recv, ar_count));
-                memset(ar_h_send, 'a', ar_count);
+
+                fill_with_random_pattern(ar_h_send, ar_count);
                 memset(ar_h_recv, 0,   ar_count);
+
+                cuda_check(cudaMemcpy(ar_d_send, ar_h_send, ar_count, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(ar_d_recv, 0,   ar_count));
+
 #elif defined(USE_HIP)
                 char *ar_d_send=nullptr;
                 char *ar_d_recv=nullptr;
@@ -881,19 +920,19 @@ int main(int argc, char **argv)
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
 
-                hipError_t a_cuerr1 = hipMemset(ar_d_send, 'a', ar_count);
+                char *ar_h_send = (char*)malloc(ar_count);
+                char *ar_h_recv = (char*)malloc(ar_count);
+                fill_with_random_pattern(ar_h_send, ar_count);
+                memset(ar_h_recv, 0,   ar_count);
+
+                hipError_t a_cuerr1 = hipMemcpy(ar_d_send, ar_h_send, ar_count, hipMemcpyHostToDevice);
                 assert(a_cuerr1 == hipSuccess);
                 hipError_t a_cuerr2 = hipMemset(ar_d_recv, 0, ar_count);
                 assert(a_cuerr2 == hipSuccess);
-
-                char *ar_h_send = (char*)malloc(ar_count);
-                char *ar_h_recv = (char*)malloc(ar_count);
-                memset(ar_h_send, 'a', ar_count);
-                memset(ar_h_recv, 0,   ar_count);
 #else
                 char *ar_send = (char*)malloc(ar_count);
                 char *ar_recv = (char*)malloc(ar_count);
-                memset(ar_send, 'a', ar_count);
+                fill_with_random_pattern(ar_send, ar_count);
                 memset(ar_recv, 0,   ar_count);
 #endif
 

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -175,7 +175,7 @@ int main(int argc, char **argv)
     CALI_CXX_MARK_FUNCTION;
 #endif
 
-    int PING_PONG_LIMIT = 10;
+    int num_iterations = 10;
     const int WINDOW_SIZE = 64; // OSU-style window exchange; no SINGLE/MULTIPLE modes
     int msg_size = 1;
     int n_nodes = 1;
@@ -207,7 +207,7 @@ int main(int argc, char **argv)
                 MPI_Finalize();
                 return 0;
             case 'i':
-                PING_PONG_LIMIT = atoi(optarg);
+                num_iterations = atoi(optarg);
                 break;
             case 'p':
                 // kept for compatibility; parse partners here if desired
@@ -251,7 +251,7 @@ int main(int argc, char **argv)
     if (rank == 0)
     {
         printf("Configuration:\n");
-        printf("PING_PONG_LIMIT: %d\n", PING_PONG_LIMIT);
+        printf("PING_PONG_LIMIT: %d\n", num_iterations);
         printf("Message size: %d bytes\n", msg_size);
         printf("Cores per socket: %d\n", sys_cores_per_socket);
         printf("Cores per node: %d\n", sys_cores_per_node);
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
         }
         rankmap << "}";
         adiak::value("rank_node_map", rankmap.str());
-        adiak::value("iterations", PING_PONG_LIMIT);
+        adiak::value("iterations", num_iterations);
         adiak::value("pingpong_num_pairs", pingpong_num_pairs);
 #endif
     }
@@ -633,7 +633,7 @@ int main(int argc, char **argv)
 
                 MPI_Barrier(pp_comm);
 
-                for (int i = 0; i < PING_PONG_LIMIT; i++)
+                for (int i = 0; i < num_iterations; i++)
                 {
                     double start = 0.0, end = 0.0;
 
@@ -827,7 +827,7 @@ int main(int argc, char **argv)
                 double max_rtt = 0.0;
                 int iters = 0;
 
-                for (int it = 0; it < PING_PONG_LIMIT; ++it)
+                for (int it = 0; it < num_iterations; ++it)
                 {
                     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -979,7 +979,7 @@ int main(int argc, char **argv)
                 double max_rtt = 0.0;
                 int iters = 0;
 
-                for(int i = 0; i < PING_PONG_LIMIT; i++)
+                for(int i = 0; i < num_iterations; i++)
                 {
                     MPI_Barrier(MPI_COMM_WORLD);
                     double t0 = MPI_Wtime();
@@ -1122,7 +1122,7 @@ int main(int argc, char **argv)
                 double max_rtt = 0.0;
                 int iters = 0;
 
-                for(int i = 0; i < PING_PONG_LIMIT; i++)
+                for(int i = 0; i < num_iterations; i++)
                 {
                     MPI_Barrier(MPI_COMM_WORLD);
                     double t0 = MPI_Wtime();

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -623,6 +623,7 @@ int main(int argc, char **argv)
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
 #endif
                 }
+                MPI_Barrier(MPI_COMM_WORLD);
 
 #if defined(USE_CALIPER)
                 CALI_MARK_END(warmup_region);
@@ -692,6 +693,7 @@ int main(int argc, char **argv)
                         ++iters;
                     }
                 }
+                MPI_Barrier(MPI_COMM_WORLD);
 
                 if (i_am_timing_rank)
                 {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -881,14 +881,15 @@ int main(int argc, char **argv)
                 int iters = 0;
 
                 // --- timed alltoall ---
+                MPI_Barrier(region_comm);
+
+                double t0 = MPI_Wtime();
+
                 for (int it = 0; it < num_iterations; ++it)
                 {
-                    MPI_Barrier(region_comm);
-
-                    double t0 = MPI_Wtime();
-
 #if defined(USE_HIP)
                     hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+                    hipDeviceSynchronize();
                     MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
                     hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
                     hipDeviceSynchronize();
@@ -899,29 +900,26 @@ int main(int argc, char **argv)
 #else
                     MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, region_comm);
 #endif
+                }
 
-                    double t1 = MPI_Wtime();
-                    double dt = t1 - t0;
+                double local_total_time = MPI_Wtime() - t0;
 
-                    double iter_max = 0.0;
-                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, region_comm); //timing for the longest rank because collective operation not finished until every rank finishes
-                    if (region_rank == 0)
-                    {
-                        alltoall_total_time += iter_max;
-                        if(iter_max < min_rtt) min_rtt = iter_max;      //min & max not computing correctly on rank 0
-                        if(iter_max > max_rtt) max_rtt = iter_max;
-                        ++iters;
+                double max_total_time = 0.0;
+                MPI_Reduce(&local_total_time, &max_total_time, 1, MPI_DOUBLE, MPI_MAX, 0, region_comm);
 
-                        double avg_rtt = (iters > 0) ? (alltoall_total_time / iters) : 0.0;
+                if (region_rank == 0)
+                {
+                    double avg_time = max_total_time / num_iterations;
+
 #if defined(USE_CALIPER)
-                        cali_set_string(comm_phase_attr, "alltoall");
-                        cali_set_double(aa_avg_time_sec_attr, avg_rtt);
-                        cali_set_double(aa_max_time_sec_attr, max_rtt);
-                        cali_set_double(aa_min_time_sec_attr, min_rtt);
-                        printf("finished iteration: %d\n", it);
-                        fflush(stdout);
+                    cali_set_string(comm_phase_attr, "alltoall");
+                    cali_set_double(aa_avg_time_sec_attr, avg_time);
+                    cali_set_double(aa_max_time_sec_attr, max_total_time);      //max total time for # iterations
+                    //cali_set_double(aa_min_time_sec_attr, avg_time);
 #endif
-                    }
+                    printf("ALLTOALL %s: total=%g s, avg_per_iter=%g s over %d iterations\n",
+                        region_label.c_str(), max_total_time, avg_time, num_iterations);
+                    fflush(stdout);
                 }
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
@@ -1227,10 +1225,13 @@ int main(int argc, char **argv)
                 double max_rtt = 0.0;
                 int iters = 0;
 
-                for(int i = 0; i < num_iterations; i++)
+                // --- timed allreduce: back-to-back MPI calls ---
+                MPI_Barrier(region_comm);
+
+                double t0 = MPI_Wtime();
+
+                for (int it = 0; it < num_iterations; ++it)
                 {
-                    MPI_Barrier(region_comm);
-                    double t0 = MPI_Wtime();
 #if defined(USE_CUDA)
                     cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
                     MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
@@ -1240,29 +1241,26 @@ int main(int argc, char **argv)
                     MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
                     hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
 #else
-                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, region_comm);
+                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM,region_comm);
 #endif
-                    double dt = MPI_Wtime() - t0;
-                    double iter_max = 0.0;
-                    MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, region_comm);
+                }
 
-                    if(region_rank == 0)
-                    {
-                        ar_total_time += iter_max;
-                        if(iter_max < min_rtt) min_rtt = iter_max;          //fix min and max calculation
-                        if(iter_max > max_rtt) max_rtt = iter_max;
-                        ++iters;
+                double local_total_time = MPI_Wtime() - t0;
+                double max_total_time = 0.0;
+                MPI_Allreduce(&local_total_time, &max_total_time, 1, MPI_DOUBLE, MPI_MAX, region_comm);
 
-                        double avg_rtt = (iters > 0) ? (ar_total_time / iters) : 0.0;
+                if (region_rank == 0)
+                {
+                    double avg_time = max_total_time / num_iterations;
 #if defined(USE_CALIPER)
-                        cali_set_string(comm_phase_attr, "allreduce");
-                        cali_set_double(ar_avg_time_sec_attr, avg_rtt);
-                        cali_set_double(ar_max_time_sec_attr, max_rtt);
-                        cali_set_double(ar_min_time_sec_attr, min_rtt);
-                        printf("finished iteration: %d\n", i);
-                        fflush(stdout);
+                    cali_set_string(comm_phase_attr, "allreduce");
+                    cali_set_double(ar_avg_time_sec_attr, avg_time);
+                    cali_set_double(ar_max_time_sec_attr, max_total_time);      //max total time for # iterations
+                    //cali_set_double(ar_min_time_sec_attr, avg_time);
 #endif
-                    }
+                    printf("ALLREDUCE %s: total=%g s, avg_per_iter=%g s over %d iterations\n",
+                        region_label.c_str(), max_total_time, avg_time, num_iterations);
+                    fflush(stdout);
                 }
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -95,6 +95,78 @@ void fill_with_random_pattern(char* buf, size_t len)
     }
 }
 
+struct RankPair {
+    int src;
+    int dst;
+};
+
+static std::vector<RankPair>
+build_pingpong_pairs(const std::string& region_label,
+                     int size,
+                     int sys_cores_per_socket,
+                     int sys_cores_per_node)
+{
+    std::vector<RankPair> pairs;
+
+    auto add_pair = [&](int s, int d) {
+        if (s < 0 || d < 0 || s >= size || d >= size)
+            return;
+        pairs.push_back({s, d});
+    };
+
+    if (region_label == "Same Node Same Socket") {
+        int rps = sys_cores_per_socket;
+        if (rps < 2) return pairs;
+
+        int s0 = 0;
+        int s1 = rps / 4;
+        int s2 = rps / 2;
+        int s3 = rps - 2;
+
+        add_pair(s0, s0 + 1);
+        add_pair(s1, s1 + 1);
+        add_pair(s2, s2 + 1);
+        add_pair(s3, s3 + 1);
+
+        return pairs;
+    }
+
+    if (region_label == "Same Node Different Socket") {
+        int rps = sys_cores_per_socket;
+        int delta = rps;
+
+        if (2 * delta > size)
+            return pairs; // not enough ranks
+
+        int srcs[4] = { 0, delta / 4, delta / 2, delta - 1 };
+
+        for (int s : srcs)
+            add_pair(s, s + delta);
+
+        return pairs;
+    }
+
+    int nodes_in_comm = 0;
+    {
+        std::stringstream ss(region_label);
+        ss >> nodes_in_comm; // stops at "nodes"
+    }
+
+    if (nodes_in_comm >= 2) {
+        int rpn   = sys_cores_per_node;
+        int delta = (nodes_in_comm / 2) * rpn;
+
+        // We spread srcs across the first node:
+        int srcs[4] = { 0, rpn / 4, rpn / 2, rpn - 1 };
+
+        for (int s : srcs)
+            add_pair(s, s + delta);
+    }
+
+    return pairs;
+}
+
+
 int main(int argc, char **argv)
 {
     int rank, size;
@@ -373,38 +445,63 @@ int main(int argc, char **argv)
         mgr[message].start();
 #endif
 
-        // ===================== PINGPONG =====================
+                // ===================== PINGPONG =====================
         if (op == OpKind::PingPong || op == OpKind::All)
         {
             for (int partner_rank : partners)
             {
                 std::string region_label = region_names[partner_rank];
 
-                if (rank != 0 && rank != partner_rank)
+                // Build the 4 (or fewer) pairs for this region
+                std::vector<RankPair> pairs =
+                    build_pingpong_pairs(region_label, size,
+                                         sys_cores_per_socket, sys_cores_per_node);
+
+                if (pairs.empty()) {
+                    if (rank == 0)
+                        printf("Skipping region %s: no valid pairs\n",
+                               region_label.c_str());
                     continue;
+                }
+
+                // Map each rank to its partner, or MPI_PROC_NULL if not in any pair
+                std::vector<int> my_partner(size, MPI_PROC_NULL);
+                for (auto &p : pairs) {
+                    my_partner[p.src] = p.dst;
+                    my_partner[p.dst] = p.src;
+                }
+
+                int partner = my_partner[rank];
+                if (partner == MPI_PROC_NULL) {
+                    // This rank does not participate in this region's pingpong
+                    continue;
+                }
 
                 if (rank == 0)
                 {
-                    printf("\n--- Testing %s (PINGPONG) between ranks 0 (%s) and %d (%s) ---\n",
-                           region_label.c_str(),
-                           all_hostnames[0], partner_rank, all_hostnames[partner_rank]);
+                    printf("\n--- Testing %s (PINGPONG) with %zu pairs ---\n",
+                           region_label.c_str(), pairs.size());
+                    for (auto &p : pairs) {
+                        printf("  pair %d (%s) <-> %d (%s)\n",
+                               p.src, all_hostnames[p.src],
+                               p.dst, all_hostnames[p.dst]);
+                    }
 
 #if defined(USE_CALIPER)
-                    std::string comm_pair = "0(" + std::string(all_hostnames[0]) + ")<->" +
-                                            std::to_string(partner_rank) + "(" + std::string(all_hostnames[partner_rank]) +
-                                            ")";
-                    all_comm_pairs.push_back(comm_pair);
-
-                    cali_set_int(src_rank_attr, 0);
-                    cali_set_int(dest_rank_attr, partner_rank);
-                    cali_set_int(src_node_attr, extract_node_number(all_hostnames[0]));
-                    cali_set_int(dest_node_attr, extract_node_number(all_hostnames[partner_rank]));
+                    // Use the first pair as representative for Caliper attributes
+                    cali_set_int(src_rank_attr, pairs[0].src);
+                    cali_set_int(dest_rank_attr, pairs[0].dst);
+                    cali_set_int(src_node_attr,
+                                 extract_node_number(all_hostnames[pairs[0].src]));
+                    cali_set_int(dest_node_attr,
+                                 extract_node_number(all_hostnames[pairs[0].dst]));
 #endif
                 }
 
                 double total_time = 0.0;
                 int warmup = 1;
 
+                // ---------- buffer allocation ----------
 #if defined(USE_HIP)
                 char *send_buf;
                 char *recv_buf;
@@ -413,11 +510,11 @@ int main(int argc, char **argv)
                 hipError_t err2 = hipMalloc((void**)&recv_buf, message);
 
                 if (err1 != hipSuccess || err2 != hipSuccess) {
-                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(err1), hipGetErrorString(err2));
+                    fprintf(stderr, "HIP malloc failed: %s %s\n",
+                            hipGetErrorString(err1), hipGetErrorString(err2));
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
 
-                // host pattern for HIP send buffer
                 {
                     char* h_rand = (char*)malloc(message);
                     fill_with_random_pattern(h_rand, (size_t)message);
@@ -455,94 +552,118 @@ int main(int argc, char **argv)
                 memset(recv_buf, 0, message);
 #endif
 
+                // ---------- warmup ----------
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region);
 #endif
-
                 for (int i = 0; i < warmup; i++)
                 {
-                    if (rank == 0)
-                    {
 #if defined(USE_HIP)
-                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD,
+                    if (rank < partner) {
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
-#elif defined(USE_CUDA)
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-#else
-                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-#endif
+                    } else {
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
-                    else if (rank == partner_rank)
-                    {
-#if defined(USE_HIP)
-                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 #elif defined(USE_CUDA)
-                        MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                    if (rank < partner) {
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                    } else {
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
                         cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
-#else
-                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
-#endif
+                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
+#else
+                    if (rank < partner) {
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                    } else {
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                    }
+#endif
                 }
-
 #if defined(USE_CALIPER)
                 CALI_MARK_END(warmup_region);
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
+
+                // ---------- timed ping-pong (multiple pairs at once) ----------
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
 
                 for (int i = 0; i < PING_PONG_LIMIT; i++)
                 {
-                    if (rank == 0)
-                    {
-#if defined(USE_CUDA)
-                        double start = MPI_Wtime();
-                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                        MPI_Recv(h_recv, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-                        double end = MPI_Wtime();
-#else
-                        double start = MPI_Wtime();
-                        MPI_Send(send_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner_rank, 0, MPI_COMM_WORLD,
+                    double local_rtt = 0.0;
+
+#if defined(USE_HIP)
+                    double start = MPI_Wtime();
+                    if (rank < partner) {
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
                                  MPI_STATUS_IGNORE);
-                        double end = MPI_Wtime();
-#endif
-                        double rtt = end - start;
-                        total_time += rtt;
-
-                        if(rtt < min_rtt) min_rtt = rtt;
-                        if(rtt > max_rtt) max_rtt = rtt;
-                        ++iters;
-
+                    } else {
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
-                    else if (rank == partner_rank)
-                    {
-#if defined(USE_CUDA)
-                        MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                    double end = MPI_Wtime();
+#elif defined(USE_CUDA)
+                    double start = MPI_Wtime();
+                    if (rank < partner) {
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                    } else {
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
                         cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
-                        MPI_Send(h_send, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                    }
+                    double end = MPI_Wtime();
 #else
-                        MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+                    double start = MPI_Wtime();
+                    if (rank < partner) {
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                    } else {
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                    }
+                    double end = MPI_Wtime();
 #endif
+                    local_rtt = end - start;
+
+                    // Take max RTT across all pairs in this region/iteration
+                    double iter_max = 0.0;
+                    MPI_Reduce(&local_rtt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+
+                    if (rank == 0) {
+                        total_time += iter_max;
+                        if (iter_max < min_rtt) min_rtt = iter_max;
+                        if (iter_max > max_rtt) max_rtt = iter_max;
+                        ++iters;
                     }
                 }
 
-                if(rank == 0)
+                if (rank == 0)
                 {
                     double avg_rtt = (iters > 0) ? (total_time / iters) : 0.0;
 #if defined(USE_CALIPER)
@@ -556,6 +677,8 @@ int main(int argc, char **argv)
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
 #endif
+
+                // ---------- cleanup ----------
 #if defined(USE_HIP)
                 hipFree(send_buf);
                 hipFree(recv_buf);

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
     const char *warmup_region_aa = "warmup_aa";
     const char *warmup_region_red = "warmup_red";
     const char *warmup_region_ar = "warmup_ar";
-    int pingpong_num_pairs = 4;
+    int pingpong_num_pairs = 1;
 
     // ---- default to PingPong ----
     OpKind op = OpKind::PingPong;

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -562,7 +562,6 @@ int main(int argc, char **argv)
                 cuda_check(cudaMemset(d_recv, 0, message);
 
 #else
-                // MPI-only path: always per-window-slot buffers (no SINGLE/MULTIPLE behavior)
                 char *send_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
                 char *recv_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
 
@@ -572,7 +571,7 @@ int main(int argc, char **argv)
                 for (int j = 0; j < WINDOW_SIZE; ++j) {
                     s_buf[j] = send_flat + (size_t)j * (size_t)message;
                     r_buf[j] = recv_flat + (size_t)j * (size_t)message;
-                    fill_with_random_pattern(s_buf[j], (size_t)message); // fill once
+                    fill_with_random_pattern(s_buf[j], (size_t)message);
                     memset(r_buf[j], 0, (size_t)message);
                 }
 
@@ -586,8 +585,7 @@ int main(int argc, char **argv)
 #endif
                 for (int i = 0; i < warmup; i++)
                 {
-#if defined(USE_HIP)
-                    // keep your original HIP blocking order
+#if defined(USE_HIP)er
                     if (rank < partner) {
                         MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                         MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
@@ -598,7 +596,6 @@ int main(int argc, char **argv)
                         MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #elif defined(USE_CUDA)
-                    // keep your original CUDA blocking order (staging through pinned host)
                     if (rank < partner) {
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
@@ -613,7 +610,6 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
-                    // OSU pattern: post all Irecvs, post all Isends, waitall sends, waitall recvs
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
                         MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
                                   MPI_COMM_WORLD, &recv_request[j]);
@@ -622,6 +618,7 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
+                    MPI_Barrier(MPI_COMM_WORLD);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
 #endif
@@ -681,6 +678,7 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
+                    MPI_Barrier(MPI_COMM_WORLD);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
 #endif

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -44,12 +44,6 @@ inline void cuda_check(cudaError_t e) {
 }
 #endif
 
-// If your MPI is GPU-aware (can send/recv device pointers), set this to 1 at compile time:
-//   -DASSUME_GPU_AWARE_MPI=1
-#ifndef ASSUME_GPU_AWARE_MPI
-#define ASSUME_GPU_AWARE_MPI 0
-#endif
-
 // ---- Operation selector (default: PingPong) ----
 enum class OpKind { All, PingPong, Alltoall, Reduce, Allreduce };
 
@@ -177,44 +171,6 @@ build_pingpong_pairs(const std::string& region_label,
     return pairs;
 }
 
-// ---------- Unified 2D payload helpers ----------
-static inline size_t row_index(int iter, int j, int window_size) {
-    return (size_t)iter * (size_t)window_size + (size_t)j;
-}
-static inline char* row_ptr(char* base, size_t bytes_per_row, size_t row) {
-    return base + row * bytes_per_row;
-}
-static inline const char* row_ptr(const char* base, size_t bytes_per_row, size_t row) {
-    return base + row * bytes_per_row;
-}
-
-// Pinned host alloc when CUDA/HIP enabled; malloc otherwise.
-// This is ONLY for host-side canonical 2D data + optional staging.
-static inline void* host_alloc(size_t bytes) {
-#if defined(USE_CUDA)
-    void* p = nullptr;
-    cuda_check(cudaMallocHost(&p, bytes));
-    return p;
-#elif defined(USE_HIP)
-    void* p = nullptr;
-    hipError_t e = hipHostMalloc(&p, bytes);
-    if (e != hipSuccess) return nullptr;
-    return p;
-#else
-    return std::malloc(bytes);
-#endif
-}
-
-static inline void host_free(void* p) {
-#if defined(USE_CUDA)
-    cuda_check(cudaFreeHost(p));
-#elif defined(USE_HIP)
-    hipHostFree(p);
-#else
-    std::free(p);
-#endif
-}
-
 int main(int argc, char **argv)
 {
     int rank, size;
@@ -261,7 +217,6 @@ int main(int argc, char **argv)
         "[-O pingpong|alltoall|reduce|allreduce|all]\n"
         "Default: -O pingpong\n";
 
-    // add 'O:' to parse the selector
     while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:O:")) != -1)
     {
         switch (opt)
@@ -274,7 +229,7 @@ int main(int argc, char **argv)
                 PING_PONG_LIMIT = atoi(optarg);
                 break;
             case 'p':
-                // kept for compatibility; you can parse partners here if desired
+                // kept for compatibility
                 break;
             case 'm':
                 msg_size = atoi(optarg);
@@ -497,81 +452,27 @@ int main(int argc, char **argv)
 #endif
 
         // ===================== PINGPONG =====================
-        // ===================== PINGPONG =====================
         if (op == OpKind::PingPong || op == OpKind::All)
         {
-            const int ITERS = PING_PONG_LIMIT;
-            const int W     = WINDOW_SIZE;
-            const size_t bytes_per_row = (size_t)message;
-            const size_t total_rows    = (size_t)ITERS * (size_t)W;
-
-            const size_t send2d_bytes      = total_rows * bytes_per_row;
-            const size_t recv_window_bytes = (size_t)W * bytes_per_row;
-
-            char* host_send_2d  = (char*)host_alloc(send2d_bytes);
-            char* host_recv_win = (char*)host_alloc(recv_window_bytes);
-            if (!host_send_2d || !host_recv_win) {
-                if (rank == 0) fprintf(stderr, "host_alloc failed\n");
-                MPI_Abort(MPI_COMM_WORLD, 1);
-            }
-
-            for (size_t r = 0; r < total_rows; ++r) {
-                fill_with_random_pattern(row_ptr(host_send_2d, bytes_per_row, r), bytes_per_row);
-            }
-            memset(host_recv_win, 0, recv_window_bytes);
-
-            std::vector<MPI_Request> sreqs(W, MPI_REQUEST_NULL);
-            std::vector<MPI_Request> rreqs(W, MPI_REQUEST_NULL);
-
-#if defined(USE_HIP)
-            char* d_send_2d = nullptr;
-            char* d_recv_win = nullptr;
-            {
-                hipError_t e1 = hipMalloc((void**)&d_send_2d, send2d_bytes);
-                hipError_t e2 = hipMalloc((void**)&d_recv_win, recv_window_bytes);
-                if (e1 != hipSuccess || e2 != hipSuccess) {
-                    fprintf(stderr, "HIP malloc failed: %s %s\n",
-                            hipGetErrorString(e1), hipGetErrorString(e2));
-                    MPI_Abort(MPI_COMM_WORLD, 1);
-                }
-                hipError_t e3 = hipMemcpy(d_send_2d, host_send_2d, send2d_bytes, hipMemcpyHostToDevice);
-                hipError_t e4 = hipMemset(d_recv_win, 0, recv_window_bytes);
-                if (e3 != hipSuccess || e4 != hipSuccess) {
-                    fprintf(stderr, "HIP memcpy/memset failed: %s %s\n",
-                            hipGetErrorString(e3), hipGetErrorString(e4));
-                    MPI_Abort(MPI_COMM_WORLD, 1);
-                }
-            }
-#elif defined(USE_CUDA)
-            int dev_count = 0;
-            cuda_check(cudaGetDeviceCount(&dev_count));
-            cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
-
-            char* d_send_2d = nullptr;
-            char* d_recv_win = nullptr;
-            cuda_check(cudaMalloc((void**)&d_send_2d, send2d_bytes));
-            cuda_check(cudaMalloc((void**)&d_recv_win, recv_window_bytes));
-            cuda_check(cudaMemcpy(d_send_2d, host_send_2d, send2d_bytes, cudaMemcpyHostToDevice));
-            cuda_check(cudaMemset(d_recv_win, 0, recv_window_bytes));
-#endif
-
             for (int partner_rank : partners)
             {
                 std::string region_label = region_names[partner_rank];
 
+                // Build up to 4 pairs for this region
                 std::vector<RankPair> pairs =
                     build_pingpong_pairs(region_label,
-                                        size,
-                                        sys_cores_per_socket,
-                                        sys_cores_per_node, pingpong_num_pairs);
+                                         size,
+                                         sys_cores_per_socket,
+                                         sys_cores_per_node, pingpong_num_pairs);
 
                 if (pairs.empty()) {
                     if (rank == 0)
                         printf("Skipping region %s: no valid pingpong pairs\n",
-                            region_label.c_str());
+                               region_label.c_str());
                     continue;
                 }
 
+                // Map each rank to its partner (or MPI_PROC_NULL if not in any pair)
                 std::vector<int> my_partner(size, MPI_PROC_NULL);
                 for (auto &p : pairs) {
                     my_partner[p.src] = p.dst;
@@ -579,88 +480,148 @@ int main(int argc, char **argv)
                 }
 
                 int partner = my_partner[rank];
-                if (partner == MPI_PROC_NULL)
+                if (partner == MPI_PROC_NULL) {
+                    // This rank does not participate in this region's pingpong
                     continue;
+                }
 
                 if (rank == 0)
                 {
                     printf("\n--- Testing %s (PINGPONG) with %zu pairs ---\n",
-                        region_label.c_str(), pairs.size());
+                           region_label.c_str(), pairs.size());
                     for (auto &p : pairs) {
                         printf("  pair %d (%s) <-> %d (%s)\n",
-                            p.src, all_hostnames[p.src],
-                            p.dst, all_hostnames[p.dst]);
+                               p.src, all_hostnames[p.src],
+                               p.dst, all_hostnames[p.dst]);
                     }
 
 #if defined(USE_CALIPER)
+                    // Use the first pair as representative for Caliper attributes
                     cali_set_int(src_rank_attr, pairs[0].src);
                     cali_set_int(dest_rank_attr, pairs[0].dst);
                     cali_set_int(src_node_attr,
-                                extract_node_number(all_hostnames[pairs[0].src]));
+                                 extract_node_number(all_hostnames[pairs[0].src]));
                     cali_set_int(dest_node_attr,
-                                extract_node_number(all_hostnames[pairs[0].dst]));
+                                 extract_node_number(all_hostnames[pairs[0].dst]));
 #endif
                 }
 
                 double total_time = 0.0;
-                const int warmup = 1;
-                const int tag_base = 1000;
+                int warmup = 1;
 
+                // ---------- buffer allocation ----------
+#if defined(USE_HIP)
+                // (kept exactly like your older HIP path: device pointers passed to MPI)
+                char *send_buf;
+                char *recv_buf;
+
+                hipError_t err1 = hipMalloc((void**)&send_buf, message);
+                hipError_t err2 = hipMalloc((void**)&recv_buf, message);
+
+                if (err1 != hipSuccess || err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n",
+                            hipGetErrorString(err1),
+                            hipGetErrorString(err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                {
+                    char* h_rand = (char*)malloc(message);
+                    fill_with_random_pattern(h_rand, (size_t)message);
+                    hipError_t cuerr1 =
+                        hipMemcpy(send_buf, h_rand, message, hipMemcpyHostToDevice);
+                    assert(cuerr1 == hipSuccess);
+                    free(h_rand);
+                }
+                hipError_t cuerr2 = hipMemset(recv_buf, 0, message);
+                assert(cuerr2 == hipSuccess);
+
+#elif defined(USE_CUDA)
+                // (kept exactly like your older CUDA path: stage through pinned host)
+                int dev_count = 0;
+                cuda_check(cudaGetDeviceCount(&dev_count));
+                cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
+
+                char *d_send = nullptr;
+                char *d_recv = nullptr;
+                cuda_check(cudaMalloc((void**)&d_send, message));
+                cuda_check(cudaMalloc((void**)&d_recv, message));
+
+                char *h_send = nullptr, *h_recv = nullptr;
+                cuda_check(cudaMallocHost((void**)&h_send, message));
+                cuda_check(cudaMallocHost((void**)&h_recv, message));
+
+                fill_with_random_pattern(h_send, (size_t)message);
+                memset(h_recv, 0, message);
+
+                cuda_check(cudaMemcpy(d_send, h_send, message, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(d_recv, 0, message);
+
+#else
+                // MPI-only: allocate + fill ONCE (no per-iteration refill)
+                char* send_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
+                char* recv_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
+
+                std::vector<char*> send_rows(WINDOW_SIZE);
+                std::vector<char*> recv_rows(WINDOW_SIZE);
+
+                for (int j = 0; j < WINDOW_SIZE; ++j) {
+                    send_rows[j] = send_flat + (size_t)j * (size_t)message;
+                    recv_rows[j] = recv_flat + (size_t)j * (size_t)message;
+
+                    fill_with_random_pattern(send_rows[j], (size_t)message); // ✅ fill once
+                    memset(recv_rows[j], 0, (size_t)message);
+                }
+
+                std::vector<MPI_Request> sreqs(WINDOW_SIZE);
+                std::vector<MPI_Request> rreqs(WINDOW_SIZE);
+#endif
+
+                // ---------- warmup ----------
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region);
 #endif
-                for (int w = 0; w < warmup; ++w)
+                const int tag_base = 1000;
+                for (int i = 0; i < warmup; i++)
                 {
-                    const int warm_iter = 0;
-
-#if defined(USE_HIP) || defined(USE_CUDA)
-#if ASSUME_GPU_AWARE_MPI
+#if defined(USE_HIP)
                     if (rank < partner) {
-                        for (int j = 0; j < W; ++j) {
-                            size_t r = row_index(warm_iter, j, W);
-                            char* d_src = d_send_2d + r * bytes_per_row;
-                            char* d_dst = d_recv_win + (size_t)j * bytes_per_row;
-                            MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
-                            MPI_Recv(d_dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        }
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
                     } else {
-                        for (int j = 0; j < W; ++j) {
-                            size_t r = row_index(warm_iter, j, W);
-                            char* d_src = d_send_2d + r * bytes_per_row;
-                            char* d_dst = d_recv_win + (size_t)j * bytes_per_row;
-                            MPI_Recv(d_dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
-                        }
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
-        #else
+#elif defined(USE_CUDA)
                     if (rank < partner) {
-                        for (int j = 0; j < W; ++j) {
-                            size_t r = row_index(warm_iter, j, W);
-                            const char* src = row_ptr(host_send_2d, bytes_per_row, r);
-                            char* dst = host_recv_win + (size_t)j * bytes_per_row;
-                            MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
-                            MPI_Recv(dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        }
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
                     } else {
-                        for (int j = 0; j < W; ++j) {
-                            size_t r = row_index(warm_iter, j, W);
-                            const char* src = row_ptr(host_send_2d, bytes_per_row, r);
-                            char* dst = host_recv_win + (size_t)j * bytes_per_row;
-                            MPI_Recv(dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
-                        }
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
-#endif
 #else
-                    for (int j = 0; j < W; ++j) {
-                        size_t r = row_index(warm_iter, j, W);
-                        MPI_Irecv(host_recv_win + (size_t)j * bytes_per_row, message, MPI_CHAR,
-                                partner, tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
-                        MPI_Isend((void*)row_ptr(host_send_2d, bytes_per_row, r), message, MPI_CHAR,
-                                partner, tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                    // ✅ NO refill here
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(recv_rows[j], message, MPI_CHAR, partner,
+                                  tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
                     }
-                    MPI_Waitall(W, rreqs.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall(W, sreqs.data(), MPI_STATUSES_IGNORE);
+
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(send_rows[j], message, MPI_CHAR, partner,
+                                  tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                    }
+
+                    MPI_Waitall(WINDOW_SIZE, rreqs.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, sreqs.data(), MPI_STATUSES_IGNORE);
 #endif
                 }
 #if defined(USE_CALIPER)
@@ -668,71 +629,66 @@ int main(int argc, char **argv)
                 CALI_MARK_BEGIN(region_label.c_str());
 #endif
 
+                // ---------- timed ping-pong ----------
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
 
+                // One rank per pair records timings (the "lower" rank)
                 bool i_am_timing_rank = (rank < partner);
+
                 MPI_Barrier(MPI_COMM_WORLD);
 
-                for (int i = 0; i < ITERS; i++)
+                for (int i = 0; i < PING_PONG_LIMIT; i++)
                 {
                     double start = 0.0, end = 0.0;
 
-#if defined(USE_HIP) || defined(USE_CUDA)
-                    if (i_am_timing_rank) start = MPI_Wtime();
-#if ASSUME_GPU_AWARE_MPI
+#if defined(USE_HIP)
                     if (rank < partner) {
-                        for (int j = 0; j < W; ++j) {
-                            size_t r = row_index(i, j, W);
-                            char* d_src = d_send_2d + r * bytes_per_row;
-                            char* d_dst = d_recv_win + (size_t)j * bytes_per_row;
-                            MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
-                            MPI_Recv(d_dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        }
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
                     } else {
-                        for (int j = 0; j < W; ++j) {
-                            size_t r = row_index(i, j, W);
-                            char* d_src = d_send_2d + r * bytes_per_row;
-                            char* d_dst = d_recv_win + (size_t)j * bytes_per_row;
-                            MPI_Recv(d_dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            MPI_Send(d_src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
-                        }
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                    }
+#elif defined(USE_CUDA)
+                    if (rank < partner) {
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                    } else {
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
-                    if (rank < partner) {
-                        for (int j = 0; j < W; ++j) {
-                            size_t r = row_index(i, j, W);
-                            const char* src = row_ptr(host_send_2d, bytes_per_row, r);
-                            char* dst = host_recv_win + (size_t)j * bytes_per_row;
-                            MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
-                            MPI_Recv(dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                        }
-                    } else {
-                        for (int j = 0; j < W; ++j) {
-                            size_t r = row_index(i, j, W);
-                            const char* src = row_ptr(host_send_2d, bytes_per_row, r);
-                            char* dst = host_recv_win + (size_t)j * bytes_per_row;
-                            MPI_Recv(dst, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                            MPI_Send((void*)src, message, MPI_CHAR, partner, tag_base + j, MPI_COMM_WORLD);
-                        }
+                    // ✅ NO refill here
+                    if (i_am_timing_rank){
+                        start = MPI_Wtime();
                     }
-#endif
-                    if (i_am_timing_rank) end = MPI_Wtime();
-#else
-                    if (i_am_timing_rank) start = MPI_Wtime();
 
-                    for (int j = 0; j < W; ++j) {
-                        size_t r = row_index(i, j, W);
-                        MPI_Irecv(host_recv_win + (size_t)j * bytes_per_row, message, MPI_CHAR, partner,
-                                tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
-                        MPI_Isend((void*)row_ptr(host_send_2d, bytes_per_row, r), message, MPI_CHAR, partner,
-                                tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(recv_rows[j], message, MPI_CHAR, partner,
+                                  tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
                     }
-                    MPI_Waitall(W, rreqs.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall(W, sreqs.data(), MPI_STATUSES_IGNORE);
 
-                    if (i_am_timing_rank) end = MPI_Wtime();
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(send_rows[j], message, MPI_CHAR, partner,
+                                  tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                    }
+
+                    MPI_Waitall(WINDOW_SIZE, rreqs.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, sreqs.data(), MPI_STATUSES_IGNORE);
+
+                    if (i_am_timing_rank){
+                        end = MPI_Wtime();
+                    }
 #endif
 
                     if (i_am_timing_rank) {
@@ -754,31 +710,35 @@ int main(int argc, char **argv)
                     cali_set_double(pp_max_time_sec_attr, max_rtt);
                     cali_set_double(pp_min_time_sec_attr, min_rtt);
 #endif
+
                     printf("PINGPONG %s pair (%d,%d): avg=%g s, min=%g s, max=%g s\n",
-                        region_label.c_str(), rank, partner,
-                        avg_rtt, min_rtt, max_rtt);
+                           region_label.c_str(), rank, partner,
+                           avg_rtt, min_rtt, max_rtt);
                 }
 
 #if defined(USE_CALIPER)
                 CALI_MARK_END(region_label.c_str());
 #endif
-            }
-#if defined(USE_HIP)
-            hipFree(d_send_2d);
-            hipFree(d_recv_win);
-#elif defined(USE_CUDA)
-            cuda_check(cudaFree(d_send_2d));
-            cuda_check(cudaFree(d_recv_win));
-#endif
-            host_free(host_send_2d);
-            host_free(host_recv_win);
-        }
 
+                // ---------- cleanup ----------
+#if defined(USE_HIP)
+                hipFree(send_buf);
+                hipFree(recv_buf);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFreeHost(h_send));
+                cuda_check(cudaFreeHost(h_recv));
+                cuda_check(cudaFree(d_send));
+                cuda_check(cudaFree(d_recv));
+#else
+                free(send_flat);
+                free(recv_flat);
+#endif
+            } // end for (partner_rank : partners)
+        }     // end if (PingPong || All)
 
         MPI_Barrier(MPI_COMM_WORLD);
 
         // ===================== ALLTOALL =====================
-        // (unchanged from your original; still fills buffers each message-size once)
         if (op == OpKind::Alltoall || op == OpKind::All)
         {
             for (int partner_rank : partners)
@@ -935,7 +895,6 @@ int main(int argc, char **argv)
         MPI_Barrier(MPI_COMM_WORLD);
 
         // ===================== REDUCE =====================
-        // (unchanged)
         if (op == OpKind::Reduce || op == OpKind::All)
         {
             for (int partner_rank : partners)
@@ -1083,7 +1042,6 @@ int main(int argc, char **argv)
         MPI_Barrier(MPI_COMM_WORLD);
 
         // ===================== ALLREDUCE =====================
-        // (unchanged)
         if (op == OpKind::Allreduce || op == OpKind::All)
         {
             for (int partner_rank : partners)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -486,13 +486,13 @@ int main(int argc, char **argv)
                     continue;
                 }
 
-                printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
-                           region_label.c_str(), pairs.size(), partner_rank);
+                // printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
+                //            region_label.c_str(), pairs.size(), partner_rank);
 
                 if (rank == 0)
                 {
-                    // printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
-                    //        region_label.c_str(), pairs.size(), partner_rank);
+                    printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
+                           region_label.c_str(), pairs.size(), partner_rank);
                     for (auto &p : pairs) {
                         printf("  pair %d (%s) <-> %d (%s)\n",
                                p.src, all_hostnames[p.src],
@@ -623,17 +623,17 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
-                    printf("rank: %d before MPI_Barrier before inside warmup %d\n", rank, i);
-                    MPI_Barrier(MPI_COMM_WORLD);
+                    // printf("rank: %d before MPI_Barrier before inside warmup %d\n", rank, i);
+                    // MPI_Barrier(MPI_COMM_WORLD);
                     printf("rank: %d after MPI_Barrier before waitall inside warmup %d\n", rank, i);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
                     printf("rank: %d After Waitall warmup %d\n", rank, i);
 #endif
                 }
-                printf("rank: %d before MPI_Barrier outside warmup\n", rank);
-                MPI_Barrier(MPI_COMM_WORLD);
-                printf("rank: %d after MPI_Barrier outside warmup\n", rank);
+                // printf("rank: %d before MPI_Barrier outside warmup\n", rank);
+                // MPI_Barrier(MPI_COMM_WORLD);
+                // printf("rank: %d after MPI_Barrier outside warmup\n", rank);
 
 #if defined(USE_CALIPER)
                 CALI_MARK_END(warmup_region);
@@ -689,8 +689,8 @@ int main(int argc, char **argv)
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
                                   MPI_COMM_WORLD, &send_request[j]);
                     }
-                    printf("rank: %d before MPI_Barrier inside iteration %d\n", rank, i);
-                    MPI_Barrier(MPI_COMM_WORLD);
+                    // printf("rank: %d before MPI_Barrier inside iteration %d\n", rank, i);
+                    // MPI_Barrier(MPI_COMM_WORLD);
                     printf("rank: %d after MPI_barrier before waitall inside iteration %d\n", rank, i);
                     MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
                     MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
@@ -706,9 +706,9 @@ int main(int argc, char **argv)
                         ++iters;
                     }
                 }
-                printf("rank: %d before MPI_Barrier outside iteration loop\n", rank);
-                MPI_Barrier(MPI_COMM_WORLD);
-                printf("rank: %d after MPI_Barrier outside iteration loop\n", rank);
+                // printf("rank: %d before MPI_Barrier outside iteration loop\n", rank);
+                // MPI_Barrier(MPI_COMM_WORLD);
+                // printf("rank: %d after MPI_Barrier outside iteration loop\n", rank);
 
                 if (i_am_timing_rank)
                 {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -71,6 +71,15 @@ static MPI_Comm make_prefix_subcomm(int active_size) {
     return sub;
 }
 
+// Make a communicator for the pair {0, partner_rank}
+static MPI_Comm make_pair_comm(int partner_rank) {
+    int rank; MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    int color = (rank == 0 || rank == partner_rank) ? (1000 + partner_rank) : MPI_UNDEFINED;
+    MPI_Comm sub = MPI_COMM_NULL;
+    MPI_Comm_split(MPI_COMM_WORLD, color, rank, &sub);
+    return sub;
+}
+
 enum class P2PMode { PingPong, BW, BiBW };
 enum class OpKind  { PingPong, Alltoall, Reduce, Allreduce };
 
@@ -372,6 +381,11 @@ int main(int argc, char **argv) {
             std::string region_label = region_names[partner_rank];
             if (rank != 0 && rank != partner_rank) continue;
 
+            // pair communicator for ranks {0, partner_rank}
+            MPI_Comm pair = make_pair_comm(partner_rank);
+            int pair_rank=-1, pair_size=0;
+            if (pair != MPI_COMM_NULL) { MPI_Comm_rank(pair,&pair_rank); MPI_Comm_size(pair,&pair_size); }
+
             if (rank == 0) {
                 printf("\n--- Testing %s between ranks 0 (%s) and %d (%s), msg=%d, mode=%s ---\n",
                        region_label.c_str(),
@@ -482,10 +496,6 @@ int main(int argc, char **argv) {
                                      h_recv, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
                                      MPI_COMM_WORLD, MPI_STATUS_IGNORE);
                         cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                        MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                     recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 #else
                         MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
                                      recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
@@ -495,7 +505,8 @@ int main(int argc, char **argv) {
                 }
             }
             CALI_MARK_END(warmup_region);
-            MPI_Barrier(MPI_COMM_WORLD);
+
+            if (pair != MPI_COMM_NULL) MPI_Barrier(pair); // pair barrier (not WORLD)
 
             // Measurements
             double total_time = 0.0;
@@ -543,7 +554,7 @@ int main(int argc, char **argv) {
 #if defined(USE_CUDA)
                             cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
 #endif
-                            MPI_Barrier(MPI_COMM_WORLD);
+                            if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
                             double t0 = MPI_Wtime();
                             for (int w = 0; w < window; ++w) {
 #if defined(USE_CUDA)
@@ -557,9 +568,9 @@ int main(int argc, char **argv) {
                             if (dt < min_t) min_t = dt;
                             if (dt > max_t) max_t = dt;
                             ++iters;
-                            MPI_Barrier(MPI_COMM_WORLD);
+                            if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
                         } else if (rank == partner_rank) {
-                            MPI_Barrier(MPI_COMM_WORLD);
+                            if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
                             for (int w = 0; w < window; ++w) {
 #if defined(USE_CUDA)
                                 MPI_Recv(h_recv, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
@@ -568,10 +579,10 @@ int main(int argc, char **argv) {
                                 MPI_Recv(recv_buf, message, MPI_CHAR, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 #endif
                             }
-                            MPI_Barrier(MPI_COMM_WORLD);
+                            if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
                         }
                     } else { // BiBW
-                        MPI_Barrier(MPI_COMM_WORLD);
+                        if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
                         double t0 = MPI_Wtime();
                         for (int w = 0; w < window; ++w) {
 #if defined(USE_CUDA)
@@ -580,10 +591,6 @@ int main(int argc, char **argv) {
                                          h_recv, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
                                          MPI_COMM_WORLD, MPI_STATUS_IGNORE);
                             cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
-#elif defined(USE_HIP)
-                            MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                         recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
-                                         MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 #else
                             MPI_Sendrecv(send_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
                                          recv_buf, message, MPI_CHAR, (rank==0?partner_rank:0), 0,
@@ -592,14 +599,15 @@ int main(int argc, char **argv) {
                         }
                         double dt = MPI_Wtime() - t0;
                         double max_dt = 0.0;
-                        MPI_Allreduce(&dt, &max_dt, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+                        if (pair != MPI_COMM_NULL)
+                            MPI_Allreduce(&dt, &max_dt, 1, MPI_DOUBLE, MPI_MAX, pair);
                         if (rank == 0) {
                             total_time += max_dt;
                             if (max_dt < min_t) min_t = max_dt;
                             if (max_dt > max_t) max_t = max_dt;
                             ++iters;
                         }
-                        MPI_Barrier(MPI_COMM_WORLD);
+                        if (pair != MPI_COMM_NULL) MPI_Barrier(pair);
                     }
                 } // iterations
 
@@ -652,6 +660,8 @@ int main(int argc, char **argv) {
 #else
             free(send_buf); free(recv_buf);
 #endif
+
+            if (pair != MPI_COMM_NULL) MPI_Comm_free(&pair);
         } // end P2P
 
         // keep everyone aligned before starting collectives

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -607,15 +607,15 @@ int main(int argc, char **argv)
 #else
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
                         MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
-                                  MPI_COMM_WORLD, &reqs[j]);
+                                  MPI_COMM_WORLD, &recv_request[j]);
                     }
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
-                                  MPI_COMM_WORLD, &reqs[WINDOW_SIZE + j]);
+                                  MPI_COMM_WORLD, &send_request[j]);
                     }
-                    //MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
-                    //MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    //MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
 #endif
                 }
 
@@ -667,15 +667,15 @@ int main(int argc, char **argv)
 #else
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
                         MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
-                                  MPI_COMM_WORLD, &reqs[j]);
+                                  MPI_COMM_WORLD, &recv_request[j]);
                     }
                     for (int j = 0; j < WINDOW_SIZE; ++j) {
                         MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
-                                  MPI_COMM_WORLD, &reqs[WINDOW_SIZE + j]);
+                                  MPI_COMM_WORLD, &send_request[j]);
                     }
-                    //MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
-                    //MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
-                    MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    //MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
 #endif
 
                     if (i_am_timing_rank) {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -557,10 +557,19 @@ int main(int argc, char **argv)
                 cuda_check(cudaMemset(d_recv, 0, message));
 
 #else
-                char *send_buf = (char *)malloc(message);
-                char *recv_buf = (char *)malloc(message);
-                fill_with_random_pattern(send_buf, (size_t)message);
-                memset(recv_buf, 0, message);
+                const int iters_total = PING_PONG_LIMIT;
+
+                char* send_flat = (char*)malloc((size_t)iters_total * (size_t)message);
+                char* recv_flat = (char*)malloc((size_t)iters_total * (size_t)message);
+
+                std::vector<char*> send_rows(iters_total);
+                std::vector<char*> recv_rows(iters_total);
+                for (int it = 0; it < iters_total; ++it) {
+                    send_rows[it] = send_flat + (size_t)it * (size_t)message;
+                    recv_rows[it] = recv_flat + (size_t)it * (size_t)message;
+                    fill_with_random_pattern(send_rows[it], (size_t)message);
+                    memset(recv_rows[it], 0, (size_t)message);
+                }
 #endif
 
                 // ---------- warmup ----------
@@ -594,14 +603,18 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
+                    int it = i % iters_total;
+                    char* srow = send_rows[it];
+                    char* rrow = recv_rows[it];
+
                     if (rank < partner) {
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
+                        MPI_Send(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                MPI_STATUS_IGNORE);
                     } else {
-                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 MPI_STATUS_IGNORE);
-                        MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                        MPI_Recv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
+                                MPI_STATUS_IGNORE);
+                        MPI_Send(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #endif
                 }
@@ -651,17 +664,18 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
+                    char* srow = send_rows[i];
+                    char* rrow = recv_rows[i];
+
                     if (rank < partner) {
-                        MPI_Isend(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
-                        MPI_Irecv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 &rreq);
+                        MPI_Isend(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
+                        MPI_Irecv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &rreq);
                     } else {
-                        MPI_Irecv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                 &rreq);
-                        MPI_Isend(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
+                        MPI_Irecv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &rreq);
+                        MPI_Isend(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
                     }
-                    MPI_Wait( &rreq, MPI_STATUS_IGNORE);
-                    MPI_Wait( &sreq, MPI_STATUS_IGNORE);
+                    MPI_Wait(&rreq, MPI_STATUS_IGNORE);
+                    MPI_Wait(&sreq, MPI_STATUS_IGNORE);
 #endif
 
                     if (i_am_timing_rank) {
@@ -705,8 +719,8 @@ int main(int argc, char **argv)
                 cuda_check(cudaFree(d_send));
                 cuda_check(cudaFree(d_recv));
 #else
-                free(send_buf);
-                free(recv_buf);
+                free(send_flat);
+                free(recv_flat);
 #endif
             } // end for (partner_rank : partners)
         }     // end if (PingPong || All)

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -489,10 +489,12 @@ int main(int argc, char **argv)
                     continue;
                 }
 
+
+
                 if (rank == 0)
                 {
-                    printf("\n--- Testing %s (PINGPONG) with %zu pairs ---\n",
-                           region_label.c_str(), pairs.size());
+                    printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
+                           region_label.c_str(), pairs.size(), partner_rank);
                     for (auto &p : pairs) {
                         printf("  pair %d (%s) <-> %d (%s)\n",
                                p.src, all_hostnames[p.src],
@@ -631,9 +633,9 @@ int main(int argc, char **argv)
                     printf("rank: %d After Waitall warmup %d\n", rank, i);
 #endif
                 }
-                printf("before MPI_Barrier outside warmup\n");
+                printf("rank: %d before MPI_Barrier outside warmup\n", rank);
                 MPI_Barrier(MPI_COMM_WORLD);
-                printf("after MPI_Barrier outside warmup\n");
+                printf("rank: %d after MPI_Barrier outside warmup\n", rank);
 
 #if defined(USE_CALIPER)
                 CALI_MARK_END(warmup_region);
@@ -706,9 +708,9 @@ int main(int argc, char **argv)
                         ++iters;
                     }
                 }
-                printf("before MPI_Barrier outside iteration loop\n");
+                printf("rank: %d before MPI_Barrier outside iteration loop\n", rank);
                 MPI_Barrier(MPI_COMM_WORLD);
-                printf("after MPI_Barrier outside iteration loop\n");
+                printf("rank: %d after MPI_Barrier outside iteration loop\n", rank);
 
                 if (i_am_timing_rank)
                 {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -1246,7 +1246,7 @@ int main(int argc, char **argv)
                     double iter_max = 0.0;
                     MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, region_comm);
 
-                    if(rank == 0)
+                    if(region_rank == 0)
                     {
                         ar_total_time += iter_max;
                         if(iter_max < min_rtt) min_rtt = iter_max;          //fix min and max calculation

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -196,6 +196,7 @@ int main(int argc, char **argv)
 #endif
 
     int PING_PONG_LIMIT = 10;
+    const int WINDOW_SIZE = 64;
     int msg_size = 1;
     int n_nodes = 1;
     int sys_cores_per_socket = 1;
@@ -557,25 +558,29 @@ int main(int argc, char **argv)
                 cuda_check(cudaMemset(d_recv, 0, message));
 
 #else
-                const int iters_total = PING_PONG_LIMIT;
+                char* send_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
+                char* recv_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
 
-                char* send_flat = (char*)malloc((size_t)iters_total * (size_t)message);
-                char* recv_flat = (char*)malloc((size_t)iters_total * (size_t)message);
+                std::vector<char*> send_rows(WINDOW_SIZE);
+                std::vector<char*> recv_rows(WINDOW_SIZE);
 
-                std::vector<char*> send_rows(iters_total);
-                std::vector<char*> recv_rows(iters_total);
-                for (int it = 0; it < iters_total; ++it) {
-                    send_rows[it] = send_flat + (size_t)it * (size_t)message;
-                    recv_rows[it] = recv_flat + (size_t)it * (size_t)message;
-                    fill_with_random_pattern(send_rows[it], (size_t)message);
-                    memset(recv_rows[it], 0, (size_t)message);
+                for (int j = 0; j < WINDOW_SIZE; ++j) {
+                    send_rows[j] = send_flat + (size_t)j * (size_t)message;
+                    recv_rows[j] = recv_flat + (size_t)j * (size_t)message;
+                    fill_with_random_pattern(send_rows[j], (size_t)message);
+                    memset(recv_rows[j], 0, (size_t)message);
                 }
+
+                std::vector<MPI_Request> sreqs(WINDOW_SIZE);
+                std::vector<MPI_Request> rreqs(WINDOW_SIZE);
+
 #endif
 
                 // ---------- warmup ----------
 #if defined(USE_CALIPER)
                 CALI_MARK_BEGIN(warmup_region);
 #endif
+                const int tag_base = 1000;
                 for (int i = 0; i < warmup; i++)
                 {
 #if defined(USE_HIP)
@@ -603,19 +608,22 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
-                    int it = i % iters_total;
-                    char* srow = send_rows[it];
-                    char* rrow = recv_rows[it];
+                    for (int j = 0; j < WINDOW_SIZE; ++j){
+                        fill_with_random_pattern(send_rows[j], (size_t)message);
+                    }                    
 
-                    if (rank < partner) {
-                        MPI_Send(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
-                        MPI_Recv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                MPI_STATUS_IGNORE);
-                    } else {
-                        MPI_Recv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
-                                MPI_STATUS_IGNORE);
-                        MPI_Send(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(recv_rows[j], message, MPI_CHAR, partner,
+                                tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
                     }
+
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(send_rows[j], message, MPI_CHAR, partner,
+                                tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                    }
+
+                    MPI_Waitall(WINDOW_SIZE, rreqs.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, sreqs.data(), MPI_STATUSES_IGNORE);
 #endif
                 }
 #if defined(USE_CALIPER)
@@ -627,17 +635,15 @@ int main(int argc, char **argv)
                 double min_rtt = std::numeric_limits<double>::infinity();
                 double max_rtt = 0.0;
                 int iters = 0;
-                MPI_Request rreq, sreq;
 
                 // One rank per pair records timings (the "lower" rank)
                 bool i_am_timing_rank = (rank < partner);
 
+                MPI_Barrier(MPI_COMM_WORLD);
+
                 for (int i = 0; i < PING_PONG_LIMIT; i++)
                 {
                     double start = 0.0, end = 0.0;
-
-                    if (i_am_timing_rank)
-                        start = MPI_Wtime();
 
 #if defined(USE_HIP)
                     if (rank < partner) {
@@ -664,18 +670,26 @@ int main(int argc, char **argv)
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
 #else
-                    char* srow = send_rows[i];
-                    char* rrow = recv_rows[i];
-
-                    if (rank < partner) {
-                        MPI_Isend(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
-                        MPI_Irecv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &rreq);
-                    } else {
-                        MPI_Irecv(rrow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &rreq);
-                        MPI_Isend(srow, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD, &sreq);
+                    for (int j = 0; j < WINDOW_SIZE; ++j){
+                        fill_with_random_pattern(send_rows[j], (size_t)message);
                     }
-                    MPI_Wait(&rreq, MPI_STATUS_IGNORE);
-                    MPI_Wait(&sreq, MPI_STATUS_IGNORE);
+
+                    if (i_am_timing_rank){
+                        start = MPI_Wtime();
+                    }
+
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(recv_rows[j], message, MPI_CHAR, partner,
+                                tag_base + j, MPI_COMM_WORLD, &rreqs[j]);
+                    }
+
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(send_rows[j], message, MPI_CHAR, partner,
+                                tag_base + j, MPI_COMM_WORLD, &sreqs[j]);
+                    }
+
+                    MPI_Waitall(WINDOW_SIZE, rreqs.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall(WINDOW_SIZE, sreqs.data(), MPI_STATUSES_IGNORE);
 #endif
 
                     if (i_am_timing_rank) {

--- a/repo/pingpong/pingpong.cpp
+++ b/repo/pingpong/pingpong.cpp
@@ -445,26 +445,28 @@ int main(int argc, char **argv)
         mgr[message].start();
 #endif
 
-                // ===================== PINGPONG =====================
+        // ===================== PINGPONG =====================
         if (op == OpKind::PingPong || op == OpKind::All)
         {
             for (int partner_rank : partners)
             {
                 std::string region_label = region_names[partner_rank];
 
-                // Build the 4 (or fewer) pairs for this region
+                // Build up to 4 pairs for this region
                 std::vector<RankPair> pairs =
-                    build_pingpong_pairs(region_label, size,
-                                         sys_cores_per_socket, sys_cores_per_node);
+                    build_pingpong_pairs(region_label,
+                                         size,
+                                         sys_cores_per_socket,
+                                         sys_cores_per_node);
 
                 if (pairs.empty()) {
                     if (rank == 0)
-                        printf("Skipping region %s: no valid pairs\n",
+                        printf("Skipping region %s: no valid pingpong pairs\n",
                                region_label.c_str());
                     continue;
                 }
 
-                // Map each rank to its partner, or MPI_PROC_NULL if not in any pair
+                // Map each rank to its partner (or MPI_PROC_NULL if not in any pair)
                 std::vector<int> my_partner(size, MPI_PROC_NULL);
                 for (auto &p : pairs) {
                     my_partner[p.src] = p.dst;
@@ -511,14 +513,16 @@ int main(int argc, char **argv)
 
                 if (err1 != hipSuccess || err2 != hipSuccess) {
                     fprintf(stderr, "HIP malloc failed: %s %s\n",
-                            hipGetErrorString(err1), hipGetErrorString(err2));
+                            hipGetErrorString(err1),
+                            hipGetErrorString(err2));
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
 
                 {
                     char* h_rand = (char*)malloc(message);
                     fill_with_random_pattern(h_rand, (size_t)message);
-                    hipError_t cuerr1 = hipMemcpy(send_buf, h_rand, message, hipMemcpyHostToDevice);
+                    hipError_t cuerr1 =
+                        hipMemcpy(send_buf, h_rand, message, hipMemcpyHostToDevice);
                     assert(cuerr1 == hipSuccess);
                     free(h_rand);
                 }
@@ -604,12 +608,17 @@ int main(int argc, char **argv)
                 double max_rtt = 0.0;
                 int iters = 0;
 
+                // One rank per pair records timings (the "lower" rank)
+                bool i_am_timing_rank = (rank < partner);
+
                 for (int i = 0; i < PING_PONG_LIMIT; i++)
                 {
-                    double local_rtt = 0.0;
+                    double start = 0.0, end = 0.0;
+
+                    if (i_am_timing_rank)
+                        start = MPI_Wtime();
 
 #if defined(USE_HIP)
-                    double start = MPI_Wtime();
                     if (rank < partner) {
                         MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                         MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
@@ -619,9 +628,7 @@ int main(int argc, char **argv)
                                  MPI_STATUS_IGNORE);
                         MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
-                    double end = MPI_Wtime();
 #elif defined(USE_CUDA)
-                    double start = MPI_Wtime();
                     if (rank < partner) {
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
@@ -635,9 +642,7 @@ int main(int argc, char **argv)
                         cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
                         MPI_Send(h_send, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
-                    double end = MPI_Wtime();
 #else
-                    double start = MPI_Wtime();
                     if (rank < partner) {
                         MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                         MPI_Recv(recv_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD,
@@ -647,31 +652,33 @@ int main(int argc, char **argv)
                                  MPI_STATUS_IGNORE);
                         MPI_Send(send_buf, message, MPI_CHAR, partner, 0, MPI_COMM_WORLD);
                     }
-                    double end = MPI_Wtime();
 #endif
-                    local_rtt = end - start;
 
-                    // Take max RTT across all pairs in this region/iteration
-                    double iter_max = 0.0;
-                    MPI_Reduce(&local_rtt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
-
-                    if (rank == 0) {
-                        total_time += iter_max;
-                        if (iter_max < min_rtt) min_rtt = iter_max;
-                        if (iter_max > max_rtt) max_rtt = iter_max;
+                    if (i_am_timing_rank) {
+                        end = MPI_Wtime();
+                        double rtt = end - start;
+                        total_time += rtt;
+                        if (rtt < min_rtt) min_rtt = rtt;
+                        if (rtt > max_rtt) max_rtt = rtt;
                         ++iters;
                     }
                 }
 
-                if (rank == 0)
+                if (i_am_timing_rank)
                 {
                     double avg_rtt = (iters > 0) ? (total_time / iters) : 0.0;
+
 #if defined(USE_CALIPER)
                     cali_set_string(comm_phase_attr, "pingpong");
                     cali_set_double(pp_avg_time_sec_attr, avg_rtt);
                     cali_set_double(pp_max_time_sec_attr, max_rtt);
                     cali_set_double(pp_min_time_sec_attr, min_rtt);
 #endif
+
+                    // Optional: print per-pair stats
+                    printf("PINGPONG %s pair (%d,%d): avg=%g s, min=%g s, max=%g s\n",
+                           region_label.c_str(), rank, partner,
+                           avg_rtt, min_rtt, max_rtt);
                 }
 
 #if defined(USE_CALIPER)
@@ -691,8 +698,8 @@ int main(int argc, char **argv)
                 free(send_buf);
                 free(recv_buf);
 #endif
-            }
-        }
+            } // end for (partner_rank : partners)
+        }     // end if (PingPong || All)
 
         MPI_Barrier(MPI_COMM_WORLD);
 

--- a/repo/pingpong/pingpong.cpp.astyle
+++ b/repo/pingpong/pingpong.cpp.astyle
@@ -1,0 +1,1200 @@
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <string>
+#include <vector>
+#include <set>
+#include <map>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <cmath>
+#include <limits>
+#include <assert.h>
+#include <limits.h>
+#include <random>
+
+#if defined(USE_CALIPER)
+#include <caliper/cali.h>
+#include <caliper/cali-manager.h>
+#include <adiak.hpp>
+#endif
+
+#ifndef USE_CALIPER
+#define CALI_CXX_MARK_FUNCTION
+#define CALI_MARK_BEGIN(...)
+#define CALI_MARK_END(...)
+#endif
+
+#if defined(USE_HIP)
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
+#endif
+
+#if defined(USE_CUDA)
+#include <cuda_runtime.h>
+inline void cuda_check(cudaError_t e) {
+    if (e != cudaSuccess) {
+        fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(e));
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+}
+#endif
+
+// ---- Operation selector (default: PingPong) ----
+enum class OpKind { All, PingPong, Alltoall, Reduce, Allreduce };
+
+const char *get_hostname_for_rank(int rank, char all_hostnames[][1024], int size)
+{
+    if (rank >= 0 && rank < size)
+        return all_hostnames[rank];
+    else
+        return "INVALID_RANK";
+}
+
+int extract_node_number(const char *hostname)
+{
+    int len = (int)strlen(hostname);
+    int num = 0;
+    int factor = 1;
+    for (int i = len - 1; i >= 0; --i)
+    {
+        if (hostname[i] >= '0' && hostname[i] <= '9')
+        {
+            num += (hostname[i] - '0') * factor;
+            factor *= 10;
+        }
+        else
+        {
+            break;
+        }
+    }
+    return num;
+}
+
+// Fill buf[0..len-1] with a repeating random pattern of length 16.
+void fill_with_random_pattern(char* buf, size_t len)
+{
+    if (!buf || len == 0)
+        return;
+
+    static thread_local std::mt19937 gen(std::random_device{}());
+    std::uniform_int_distribution<int> dist(0, 25); // 'a'..'z'
+
+    char pattern[16];
+    for (int i = 0; i < 16; ++i) {
+        pattern[i] = static_cast<char>('a' + dist(gen));
+    }
+
+    for (size_t i = 0; i < len; ++i) {
+        buf[i] = pattern[i % 16];
+    }
+}
+
+struct RankPair {
+    int src;
+    int dst;
+};
+
+static std::vector<RankPair>
+build_pingpong_pairs(const std::string& region_label,
+                     int size,
+                     int sys_cores_per_socket,
+                     int sys_cores_per_node,
+                     int max_pairs)
+{
+    std::vector<RankPair> pairs;
+
+    auto add_pair = [&](int s, int d) {
+        if (s < 0 || d < 0 || s >= size || d >= size)
+            return;
+        pairs.push_back({s, d});
+    };
+
+    if (region_label == "Same Node Same Socket") {
+        add_pair(0, 1);
+        return pairs;
+    }
+
+    if (region_label == "Same Node Different Socket") {
+        int rps = sys_cores_per_socket;
+        int half = rps / 2;
+
+        add_pair(0, half);
+
+        return pairs;
+    }
+
+    int nodes_in_comm = 0;
+    {
+        std::stringstream ss(region_label);
+        ss >> nodes_in_comm; // stops at "nodes"
+    }
+
+    if (nodes_in_comm >= 2) {
+        int rpn   = sys_cores_per_node;
+        int delta = (nodes_in_comm / 2) * rpn;
+
+        // We spread srcs across the first node:
+        int srcs[4] = { 0, rpn / 4, rpn / 2, rpn - 1 };
+
+        for (int s : srcs)
+            add_pair(s, s + delta);
+    }
+
+    if (max_pairs > 0 && (int)pairs.size() > max_pairs){
+        pairs.resize(max_pairs);
+    }
+
+    return pairs;
+}
+
+int main(int argc, char **argv)
+{
+    int rank, size;
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    char my_hostname[1024];
+    gethostname(my_hostname, 1023);
+    my_hostname[1023] = '\0';
+    char all_hostnames[size][1024];
+    MPI_Gather(my_hostname, 1024, MPI_CHAR, all_hostnames, 1024, MPI_CHAR, 0,
+               MPI_COMM_WORLD);
+
+#if defined(USE_CALIPER)
+    std::vector<std::string> all_comm_pairs;
+    static std::map<int, cali::ConfigManager> mgr;
+    MPI_Comm adiak_comm = MPI_COMM_WORLD;
+    adiak::init(&adiak_comm);
+    adiak::collect_all();
+    CALI_CXX_MARK_FUNCTION;
+#endif
+
+    int num_iterations = 10;
+    const int WINDOW_SIZE = 64; // OSU-style window exchange; no SINGLE/MULTIPLE modes
+    int msg_size = 1;
+    int n_nodes = 1;
+    int sys_cores_per_socket = 1;
+    int sys_cores_per_node = 1;
+    std::string metadata;
+    const char *warmup_region = "warmup";
+    const char *warmup_region_aa = "warmup_aa";
+    const char *warmup_region_red = "warmup_red";
+    const char *warmup_region_ar = "warmup_ar";
+    int pingpong_num_pairs = 1;
+
+    // ---- default to PingPong ----
+    OpKind op = OpKind::PingPong;
+
+    int opt;
+    const char *usage =
+        "Usage: %s [-h] [-i n-iterations] [-p rank1,rank2] [-m msg_sz] "
+        "[-n n_nodes] [-s sys_cores_per_socket] [-c sys_cores_per_node] [-b metadata] "
+        "[-O pingpong|alltoall|reduce|allreduce|all]\n"
+        "Default: -O pingpong\n";
+
+    while ((opt = getopt(argc, argv, "hi:p:m:n:s:c:b:O:")) != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                printf(usage, argv[0]);
+                MPI_Finalize();
+                return 0;
+            case 'i':
+                num_iterations = atoi(optarg);
+                break;
+            case 'p':
+                // kept for compatibility; parse partners here if desired
+                break;
+            case 'm':
+                msg_size = atoi(optarg);
+                break;
+            case 'n':
+                n_nodes = atoi(optarg);
+                break;
+            case 's':
+                sys_cores_per_socket = atoi(optarg);
+                break;
+            case 'c':
+                sys_cores_per_node = atoi(optarg);
+                break;
+            case 'b':
+                metadata = optarg;
+                break;
+            case 'O':
+            {
+                std::string s = optarg ? std::string(optarg) : std::string();
+                if (s == "pingpong")      op = OpKind::PingPong;
+                else if (s == "alltoall") op = OpKind::Alltoall;
+                else if (s == "reduce")   op = OpKind::Reduce;
+                else if (s == "allreduce")op = OpKind::Allreduce;
+                else if (s == "all")      op = OpKind::All;
+                else {
+                    if (rank == 0)
+                        fprintf(stderr, "Unknown -O value '%s'. Expected pingpong|alltoall|reduce|allreduce|all\n", s.c_str());
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+                break;
+            }
+            default:
+                if (rank == 0) printf(usage, argv[0]);
+                MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+    }
+
+    if (rank == 0)
+    {
+        printf("Configuration:\n");
+        printf("PING_PONG_LIMIT: %d\n", num_iterations);
+        printf("Message size: %d bytes\n", msg_size);
+        printf("Cores per socket: %d\n", sys_cores_per_socket);
+        printf("Cores per node: %d\n", sys_cores_per_node);
+        printf("Nodes: %d\n", n_nodes);
+        printf("World size: %d\n", size);
+        printf("Mode (-O): %s\n",
+               op == OpKind::PingPong ? "pingpong" :
+               op == OpKind::Alltoall ? "alltoall" :
+               op == OpKind::Reduce   ? "reduce" :
+               op == OpKind::Allreduce? "allreduce" : "all");
+
+#if defined(USE_CALIPER)
+        std::stringstream rankmap;
+        rankmap << "{";
+        for (int i = 0; i < size; ++i)
+        {
+            rankmap << "\"" << i << "\": \"" << all_hostnames[i] << "\"";
+            if (i < size - 1)
+                rankmap << ", ";
+        }
+        rankmap << "}";
+        adiak::value("rank_node_map", rankmap.str());
+        adiak::value("iterations", num_iterations);
+        adiak::value("pingpong_num_pairs", pingpong_num_pairs);
+#endif
+    }
+
+#if defined(USE_CALIPER)
+    cali_id_t src_rank_attr = cali_create_attribute("src_rank", CALI_TYPE_INT,
+                              CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t dest_rank_attr = cali_create_attribute("dest_rank", CALI_TYPE_INT,
+                               CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t src_node_attr = cali_create_attribute("src_node", CALI_TYPE_INT,
+                              CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t dest_node_attr = cali_create_attribute("dest_node", CALI_TYPE_INT,
+                               CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t message_size_attr = cali_create_attribute("message_size_bytes",
+                                  CALI_TYPE_INT, CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t comm_phase_attr = cali_create_attribute("comm_phase", CALI_TYPE_STRING,
+                                CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t aa_avg_time_sec_attr = cali_create_attribute("aa_avg_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t aa_max_time_sec_attr = cali_create_attribute("aa_max_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t aa_min_time_sec_attr = cali_create_attribute("aa_min_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t pp_avg_time_sec_attr = cali_create_attribute("pp_avg_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t pp_max_time_sec_attr = cali_create_attribute("pp_max_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t pp_min_time_sec_attr = cali_create_attribute("pp_min_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t red_avg_time_sec_attr = cali_create_attribute("red_avg_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t red_max_time_sec_attr = cali_create_attribute("red_max_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t red_min_time_sec_attr = cali_create_attribute("red_min_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t ar_avg_time_sec_attr  = cali_create_attribute("ar_avg_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t ar_max_time_sec_attr  = cali_create_attribute("ar_max_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+    cali_id_t ar_min_time_sec_attr  = cali_create_attribute("ar_min_time_sec", CALI_TYPE_DOUBLE,
+                                 CALI_ATTR_ASVALUE | CALI_ATTR_AGGREGATABLE);
+
+    const char *src_dest_attributes = R"json(
+        {
+            "name": "pingpong_attributes",
+            "type": "boolean",
+            "category": "metric",
+            "description": "Collect pingpong attributes",
+            "query":
+            [
+            {
+                "level": "local",
+                "select":
+                [
+                {"expr": "any(max#src_rank)", "as": "src_rank"},
+                {"expr": "any(max#dest_rank)", "as": "dest_rank"},
+                {"expr": "any(max#src_node)", "as": "src_node"},
+                {"expr": "any(max#dest_node)", "as": "dest_node"},
+                {"expr": "any(max#message_size_bytes)", "as": "message_size_bytes"},
+                {"expr": "any(max#aa_avg_time_sec)", "as" : "aa_avg_s"},
+                {"expr": "any(max#aa_max_time_sec)", "as" : "aa_max_s"},
+                {"expr": "any(max#aa_min_time_sec)", "as" : "aa_min_s"},
+                {"expr": "any(max#pp_avg_time_sec)", "as" : "pp_avg_s"},
+                {"expr": "any(max#pp_max_time_sec)", "as" : "pp_max_s"},
+                {"expr": "any(max#pp_min_time_sec)", "as" : "pp_min_s"},
+                {"expr": "any(max#red_avg_time_sec)", "as" : "red_avg_s"},
+                {"expr": "any(max#red_max_time_sec)", "as" : "red_max_s"},
+                {"expr": "any(max#red_min_time_sec)", "as" : "red_min_s"},
+                {"expr": "any(max#ar_avg_time_sec)", "as" : "ar_avg_s"},
+                {"expr": "any(max#ar_max_time_sec)", "as" : "ar_max_s"},
+                {"expr": "any(max#ar_min_time_sec)", "as" : "ar_min_s"}
+                ],
+                "group by": ["comm_phase"],
+            },
+            {
+                "level": "cross",
+                "select":
+                [
+                {"expr": "any(any#max#src_rank)", "as": "src_rank"},
+                {"expr": "any(any#max#dest_rank)", "as": "dest_rank"},
+                {"expr": "any(any#max#src_node)", "as": "src_node"},
+                {"expr": "any(any#max#dest_node)", "as": "dest_node"},
+                {"expr": "any(any#max#message_size_bytes)", "as": "message_size_bytes"},
+                {"expr": "any(any#max#aa_avg_time_sec)", "as" : "aa_avg_s"},
+                {"expr": "any(any#max#aa_max_time_sec)", "as" : "aa_max_s"},
+                {"expr": "any(any#max#aa_min_time_sec)", "as" : "aa_min_s"},
+                {"expr": "any(any#max#pp_avg_time_sec)", "as" : "pp_avg_s"},
+                {"expr": "any(any#max#pp_max_time_sec)", "as" : "pp_max_s"},
+                {"expr": "any(any#max#pp_min_time_sec)", "as" : "pp_min_s"},
+                {"expr": "any(any#max#red_avg_time_sec)", "as" : "red_avg_s"},
+                {"expr": "any(any#max#red_max_time_sec)", "as" : "red_max_s"},
+                {"expr": "any(any#max#red_min_time_sec)", "as" : "red_min_s"},
+                {"expr": "any(any#max#ar_avg_time_sec)", "as" : "ar_avg_s"},
+                {"expr": "any(any#max#ar_max_time_sec)", "as" : "ar_max_s"},
+                {"expr": "any(any#max#ar_min_time_sec)", "as" : "ar_min_s"}
+                ],
+                "group by": ["comm_phase"],
+            }
+            ]
+        }
+        )json";
+#endif
+
+    auto now = std::chrono::system_clock::now();
+    std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+    std::stringstream timestamp;
+    timestamp << std::put_time(std::localtime(&now_time), "%Y%m%d_%H%M%S");
+
+    int P = sys_cores_per_node * n_nodes;
+    std::vector<int> partners;
+    std::map<int, std::string> region_names;
+
+    int current_nodes = n_nodes;
+    int current_p = P;
+
+    while (current_p > 2)
+    {
+        int partner_rank = current_p - 1;
+        std::string label;
+        if (current_nodes >= 2)
+            label = std::to_string(current_nodes) + " nodes";
+        else
+            label = "Same Node Different Socket";
+
+        if (partner_rank > 0 && partner_rank < size)
+        {
+            partners.push_back(partner_rank);
+            region_names[partner_rank] = label;
+        }
+        current_nodes = current_nodes / 2;
+        current_p = current_nodes * sys_cores_per_node;
+    }
+
+    // Always add same node same socket as 0 <-> 1
+    if (1 < size)
+    {
+        partners.push_back(1);
+        region_names[1] = "Same Node Same Socket";
+    }
+
+    for (int message = msg_size; message <= pow(msg_size, 6); message *= 8)
+    {
+#if defined(USE_CALIPER)
+        std::string profile = "spot(output=" + std::to_string(message) + "_" +
+                              timestamp.str() +
+                              ".cali, profile.mpi),metadata(file=" + metadata +
+                              "),metadata(file=/etc/node_info.json,keys=\"host.os\")";
+
+        cali_set_int(message_size_attr, message);
+
+        mgr[message].add_option_spec(src_dest_attributes);
+        mgr[message].set_default_parameter("pingpong_attributes", "true");
+        adiak::value("message_size", message);
+        mgr[message].add(profile.c_str());
+        mgr[message].start();
+#endif
+
+        // ===================== PINGPONG =====================
+        if (op == OpKind::PingPong || op == OpKind::All)
+        {
+            for (int partner_rank : partners)
+            {
+                std::string region_label = region_names[partner_rank];
+
+                // Build up to N pairs for this region
+                std::vector<RankPair> pairs =
+                    build_pingpong_pairs(region_label,
+                                         size,
+                                         sys_cores_per_socket,
+                                         sys_cores_per_node,
+                                         pingpong_num_pairs);
+
+                if (pairs.empty()) {
+                    if (rank == 0)
+                        printf("Skipping region %s: no valid pingpong pairs\n",
+                               region_label.c_str());
+                    continue;
+                }
+
+                // Map each rank to its partner (or MPI_PROC_NULL if not in any pair)
+                std::vector<int> my_partner(size, MPI_PROC_NULL);
+                for (auto &p : pairs) {
+                    my_partner[p.src] = p.dst;
+                    my_partner[p.dst] = p.src;
+                }
+
+                int partner = my_partner[rank];
+
+                // ---- CLEAN FIX #1: split communicator so only paired ranks participate ----
+                const int active = (partner != MPI_PROC_NULL);
+                MPI_Comm pp_comm = MPI_COMM_NULL;
+                MPI_Comm_split(MPI_COMM_WORLD, active ? 0 : MPI_UNDEFINED, rank, &pp_comm);
+
+                if (!active) {
+                    // Not in any pair for this region: do NOT touch barriers inside this region
+                    continue;
+                }
+
+                if (rank == 0)
+                {
+                    printf("\n--- Testing %s (PINGPONG) with %zu pairs --- (partner rank: %d) \n",
+                           region_label.c_str(), pairs.size(), partner_rank);
+                    for (auto &p : pairs) {
+                        printf("  pair %d (%s) <-> %d (%s)\n",
+                               p.src, all_hostnames[p.src],
+                               p.dst, all_hostnames[p.dst]);
+                    }
+                    fflush(stdout);
+
+#if defined(USE_CALIPER)
+                    // Use the first pair as representative for Caliper attributes
+                    cali_set_int(src_rank_attr, pairs[0].src);
+                    cali_set_int(dest_rank_attr, pairs[0].dst);
+                    cali_set_int(src_node_attr,
+                                 extract_node_number(all_hostnames[pairs[0].src]));
+                    cali_set_int(dest_node_attr,
+                                 extract_node_number(all_hostnames[pairs[0].dst]));
+#endif
+                }
+
+                double total_time = 0.0;
+                int warmup = 1;
+
+                const int base_tag = 1000 + ((partner_rank % 2000) * 10);
+                const int TAG_A = base_tag + 0;
+                const int TAG_B = base_tag + 1;
+
+                // OSU-style directional tags for CPU path
+                const int my_recv_tag = (rank < partner) ? TAG_A : TAG_B;
+                const int my_send_tag = (rank < partner) ? TAG_B : TAG_A;
+
+                // ---------- buffer allocation ----------
+#if defined(USE_HIP)
+                char *send_buf;
+                char *recv_buf;
+
+                hipError_t err1 = hipMalloc((void**)&send_buf, message);
+                hipError_t err2 = hipMalloc((void**)&recv_buf, message);
+
+                if (err1 != hipSuccess || err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n",
+                            hipGetErrorString(err1),
+                            hipGetErrorString(err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                {
+                    char* h_rand = (char*)malloc(message);
+                    fill_with_random_pattern(h_rand, (size_t)message);
+                    hipError_t cuerr1 =
+                        hipMemcpy(send_buf, h_rand, message, hipMemcpyHostToDevice);
+                    assert(cuerr1 == hipSuccess);
+                    free(h_rand);
+                }
+                hipError_t cuerr2 = hipMemset(recv_buf, 0, message);
+                assert(cuerr2 == hipSuccess);
+
+#elif defined(USE_CUDA)
+                int dev_count = 0;
+                cuda_check(cudaGetDeviceCount(&dev_count));
+                cuda_check(cudaSetDevice(rank % (dev_count > 0 ? dev_count : 1)));
+
+                char *d_send = nullptr;
+                char *d_recv = nullptr;
+                cuda_check(cudaMalloc((void**)&d_send, message));
+                cuda_check(cudaMalloc((void**)&d_recv, message));
+
+                char *h_send = nullptr, *h_recv = nullptr;
+                cuda_check(cudaMallocHost((void**)&h_send, message));
+                cuda_check(cudaMallocHost((void**)&h_recv, message));
+
+                fill_with_random_pattern(h_send, (size_t)message);
+                memset(h_recv, 0, message);
+
+                cuda_check(cudaMemcpy(d_send, h_send, message, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(d_recv, 0, message));
+
+#else
+                char *send_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
+                char *recv_flat = (char*)malloc((size_t)WINDOW_SIZE * (size_t)message);
+
+                std::vector<char*> s_buf(WINDOW_SIZE);
+                std::vector<char*> r_buf(WINDOW_SIZE);
+
+                for (int j = 0; j < WINDOW_SIZE; ++j) {
+                    s_buf[j] = send_flat + (size_t)j * (size_t)message;
+                    r_buf[j] = recv_flat + (size_t)j * (size_t)message;
+                    fill_with_random_pattern(s_buf[j], (size_t)message);
+                    memset(r_buf[j], 0, (size_t)message);
+                }
+
+                std::vector<MPI_Request> send_request(WINDOW_SIZE);
+                std::vector<MPI_Request> recv_request(WINDOW_SIZE);
+                std::vector<MPI_Request> reqs(2 * WINDOW_SIZE);
+#endif
+
+                // Sync ONLY participating ranks
+                MPI_Barrier(pp_comm);
+
+                // ---------- warmup ----------
+#if defined(USE_CALIPER)
+                CALI_MARK_BEGIN(warmup_region);
+#endif
+                for (int i = 0; i < warmup; i++)
+                {
+#if defined(USE_HIP)
+                    if (rank < partner) {
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                    } else {
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
+                    }
+#elif defined(USE_CUDA)
+                    if (rank < partner) {
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                    } else {
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, TAG_A, MPI_COMM_WORLD);
+                    }
+#else
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
+                                  MPI_COMM_WORLD, &reqs[j]);
+                    }
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
+                                  MPI_COMM_WORLD, &reqs[WINDOW_SIZE + j]);
+                    }
+                    //MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    //MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
+#endif
+                }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_END(warmup_region);
+                CALI_MARK_BEGIN(region_label.c_str());
+#endif
+
+                // ---------- timed ping-pong ----------
+                double min_rtt = std::numeric_limits<double>::infinity();
+                double max_rtt = 0.0;
+                int iters = 0;
+
+                bool i_am_timing_rank = (rank < partner);
+
+                MPI_Barrier(pp_comm);
+
+                for (int i = 0; i < num_iterations; i++)
+                {
+                    double start = 0.0, end = 0.0;
+
+                    if (i_am_timing_rank)
+                        start = MPI_Wtime();
+
+#if defined(USE_HIP)
+                    if (rank < partner) {
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                    } else {
+                        MPI_Recv(recv_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        MPI_Send(send_buf, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
+                    }
+#elif defined(USE_CUDA)
+                    if (rank < partner) {
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                    } else {
+                        MPI_Recv(h_recv, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD,
+                                 MPI_STATUS_IGNORE);
+                        cuda_check(cudaMemcpy(d_recv, h_recv, message, cudaMemcpyHostToDevice));
+                        cuda_check(cudaMemcpy(h_send, d_send, message, cudaMemcpyDeviceToHost));
+                        MPI_Send(h_send, message, MPI_CHAR, partner, TAG_B, MPI_COMM_WORLD);
+                    }
+#else
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Irecv(r_buf[j], message, MPI_CHAR, partner, my_recv_tag,
+                                  MPI_COMM_WORLD, &reqs[j]);
+                    }
+                    for (int j = 0; j < WINDOW_SIZE; ++j) {
+                        MPI_Isend(s_buf[j], message, MPI_CHAR, partner, my_send_tag,
+                                  MPI_COMM_WORLD, &reqs[WINDOW_SIZE + j]);
+                    }
+                    //MPI_Waitall(WINDOW_SIZE, send_request.data(), MPI_STATUSES_IGNORE);
+                    //MPI_Waitall(WINDOW_SIZE, recv_request.data(), MPI_STATUSES_IGNORE);
+                    MPI_Waitall( (int)reqs.size() , reqs.data() , MPI_STATUSES_IGNORE);
+#endif
+
+                    if (i_am_timing_rank) {
+                        end = MPI_Wtime();
+                        double rtt = end - start;
+                        total_time += rtt;
+                        if (rtt < min_rtt) min_rtt = rtt;
+                        if (rtt > max_rtt) max_rtt = rtt;
+                        ++iters;
+                    }
+                }
+
+                MPI_Barrier(pp_comm);
+
+                if (i_am_timing_rank)
+                {
+                    double avg_rtt = (iters > 0) ? (total_time / iters) : 0.0;
+
+#if defined(USE_CALIPER)
+                    cali_set_string(comm_phase_attr, "pingpong");
+                    cali_set_double(pp_avg_time_sec_attr, avg_rtt);
+                    cali_set_double(pp_max_time_sec_attr, max_rtt);
+                    cali_set_double(pp_min_time_sec_attr, min_rtt);
+#endif
+
+                    printf("PINGPONG %s pair (%d,%d): avg=%g s, min=%g s, max=%g s\n",
+                           region_label.c_str(), rank, partner,
+                           avg_rtt, min_rtt, max_rtt);
+                    fflush(stdout);
+                }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_END(region_label.c_str());
+#endif
+
+                // ---------- cleanup ----------
+#if defined(USE_HIP)
+                hipFree(send_buf);
+                hipFree(recv_buf);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFreeHost(h_send));
+                cuda_check(cudaFreeHost(h_recv));
+                cuda_check(cudaFree(d_send));
+                cuda_check(cudaFree(d_recv));
+#else
+                free(send_flat);
+                free(recv_flat);
+#endif
+
+                MPI_Comm_free(&pp_comm);
+
+            } // end for (partner_rank : partners)
+
+            if (rank == 0) printf("Done with Pingpong\n");
+        }     // end if (PingPong || All)
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // ===================== ALLTOALL =====================
+        if (op == OpKind::Alltoall || op == OpKind::All)
+        {
+            for (int partner_rank : partners)
+            {
+                std::string region_label = region_names[partner_rank];
+
+                size_t aa_bytes_per_rank = static_cast<size_t>(message);
+                size_t aa_total_bytes = aa_bytes_per_rank * static_cast<size_t>(size);
+
+                int warmup = 1;
+                double alltoall_total_time = 0.0;
+
+#if defined(USE_HIP)
+                char *aa_send_dev;
+                char *aa_recv_dev;
+
+                hipError_t a_err1 = hipMalloc((void**)&aa_send_dev, aa_total_bytes);
+                hipError_t a_err2 = hipMalloc((void**)&aa_recv_dev, aa_total_bytes);
+
+                if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                char *aa_send_host = (char*) malloc(aa_total_bytes);
+                char *aa_recv_host = (char*) malloc(aa_total_bytes);
+                fill_with_random_pattern(aa_send_host, aa_total_bytes);
+                memset(aa_recv_host, 0, aa_total_bytes);
+
+                hipError_t a_cuerr1 = hipMemcpy(aa_send_dev, aa_send_host, aa_total_bytes, hipMemcpyHostToDevice);
+                assert(a_cuerr1 == hipSuccess);
+                hipError_t a_cuerr2 = hipMemset(aa_recv_dev, 0, aa_total_bytes);
+                assert(a_cuerr2 == hipSuccess);
+
+#elif defined(USE_CUDA)
+                int a_dev_count = 0;
+                cuda_check(cudaGetDeviceCount(&a_dev_count));
+                cuda_check(cudaSetDevice(rank % (a_dev_count > 0 ? a_dev_count : 1)));
+
+                char *ad_send = nullptr;
+                char *ad_recv = nullptr;
+                cuda_check(cudaMalloc((void**)&ad_send, aa_total_bytes));
+                cuda_check(cudaMalloc((void**)&ad_recv, aa_total_bytes));
+
+                char *ah_send = nullptr;
+                char *ah_recv = nullptr;
+                cuda_check(cudaMallocHost((void**)&ah_send, aa_total_bytes));
+                cuda_check(cudaMallocHost((void**)&ah_recv, aa_total_bytes));
+
+                fill_with_random_pattern(ah_send, aa_total_bytes);
+                memset(ah_recv, 0, aa_total_bytes);
+
+                cuda_check(cudaMemcpy(ad_send, ah_send, aa_total_bytes, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(ad_recv, 0, aa_total_bytes));
+
+#else
+                char *aa_send = (char*) malloc(aa_total_bytes);
+                char *aa_recv = (char*) malloc(aa_total_bytes);
+                fill_with_random_pattern(aa_send, aa_total_bytes);
+                memset(aa_recv,  0, aa_total_bytes);
+#endif
+
+#if defined(USE_CALIPER)
+                CALI_MARK_BEGIN(warmup_region_aa);
+#endif
+
+                for (int i = 0; i < warmup; i++)
+                {
+#if defined(USE_HIP)
+                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+                    hipDeviceSynchronize();
+                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+                    hipDeviceSynchronize();
+#elif defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
+                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
+#else
+                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+#endif
+                }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_END(warmup_region_aa);
+                CALI_MARK_BEGIN(region_label.c_str());
+#endif
+
+                double min_rtt = std::numeric_limits<double>::infinity();
+                double max_rtt = 0.0;
+                int iters = 0;
+
+                for (int it = 0; it < num_iterations; ++it)
+                {
+                    MPI_Barrier(MPI_COMM_WORLD);
+
+                    double t0 = MPI_Wtime();
+
+#if defined(USE_HIP)
+                    hipMemcpy(aa_send_host, aa_send_dev, aa_total_bytes, hipMemcpyDeviceToHost);
+                    MPI_Alltoall(aa_send_host, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv_host, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    hipMemcpy(aa_recv_dev, aa_recv_host, aa_total_bytes, hipMemcpyHostToDevice);
+                    hipDeviceSynchronize();
+#elif defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ah_send, ad_send, aa_total_bytes, cudaMemcpyDeviceToHost));
+                    MPI_Alltoall(ah_send, (int)aa_bytes_per_rank, MPI_CHAR, ah_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(ad_recv, ah_recv, aa_total_bytes, cudaMemcpyHostToDevice));
+#else
+                    MPI_Alltoall(aa_send, (int)aa_bytes_per_rank, MPI_CHAR, aa_recv, (int)aa_bytes_per_rank, MPI_CHAR, MPI_COMM_WORLD);
+#endif
+
+                    double t1 = MPI_Wtime();
+                    double dt = t1 - t0;
+
+                    double iter_max = 0.0;
+                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+                    if (rank == 0)
+                    {
+                        alltoall_total_time += iter_max;
+                        if(dt < min_rtt) min_rtt = dt;
+                        if(dt > max_rtt) max_rtt = dt;
+                        ++iters;
+
+                        double avg_rtt = (iters > 0) ? (alltoall_total_time / iters) : 0.0;
+#if defined(USE_CALIPER)
+                        cali_set_string(comm_phase_attr, "alltoall");
+                        cali_set_double(aa_avg_time_sec_attr, avg_rtt);
+                        cali_set_double(aa_max_time_sec_attr, max_rtt);
+                        cali_set_double(aa_min_time_sec_attr, min_rtt);
+#endif
+                    }
+                }
+#if defined(USE_CALIPER)
+                CALI_MARK_END(region_label.c_str());
+#endif
+
+#if defined(USE_HIP)
+                free(aa_send_host);
+                free(aa_recv_host);
+                hipFree(aa_send_dev);
+                hipFree(aa_recv_dev);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFreeHost(ah_send));
+                cuda_check(cudaFreeHost(ah_recv));
+                cuda_check(cudaFree(ad_send));
+                cuda_check(cudaFree(ad_recv));
+#else
+                free(aa_send);
+                free(aa_recv);
+#endif
+            }
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // ===================== REDUCE =====================
+        if (op == OpKind::Reduce || op == OpKind::All)
+        {
+            for (int partner_rank : partners)
+            {
+                std::string region_label = region_names[partner_rank];
+
+                size_t red_count = static_cast<size_t>(message);
+                if (red_count > INT_MAX) {
+                    if (rank == 0) fprintf(stderr, "Reduce count too large\n");
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                int warmup = 1;
+                double red_total_time = 0.0;
+
+#if defined(USE_CUDA)
+                char *rd_d_send=nullptr;
+                char *rd_d_recv=nullptr;
+
+                cuda_check(cudaMalloc((void**)&rd_d_send, red_count));
+                cuda_check(cudaMalloc((void**)&rd_d_recv, red_count));
+
+                char *rd_h_send=nullptr;
+                char *rd_h_recv=nullptr;
+                cuda_check(cudaMallocHost((void**)&rd_h_send, red_count));
+                cuda_check(cudaMallocHost((void**)&rd_h_recv, red_count));
+
+                fill_with_random_pattern(rd_h_send, red_count);
+                memset(rd_h_recv, 0,   red_count);
+
+                cuda_check(cudaMemcpy(rd_d_send, rd_h_send, red_count, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(rd_d_recv, 0,   red_count));
+
+#elif defined(USE_HIP)
+                char *rd_d_send=nullptr;
+                char *rd_d_recv=nullptr;
+
+                hipError_t a_err1 = hipMalloc((void**)&rd_d_send, red_count);
+                hipError_t a_err2 = hipMalloc((void**)&rd_d_recv, red_count);
+
+                if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                char *rd_h_send = (char*)malloc(red_count);
+                char *rd_h_recv = (char*)malloc(red_count);
+                fill_with_random_pattern(rd_h_send, red_count);
+                memset(rd_h_recv, 0,   red_count);
+
+                hipError_t a_cuerr1 = hipMemcpy(rd_d_send, rd_h_send, red_count, hipMemcpyHostToDevice);
+                assert(a_cuerr1 == hipSuccess);
+                hipError_t a_cuerr2 = hipMemset(rd_d_recv, 0, red_count);
+                assert(a_cuerr2 == hipSuccess);
+#else
+                char *rd_send = (char*)malloc(red_count);
+                char *rd_recv = (char*)malloc(red_count);
+                fill_with_random_pattern(rd_send, red_count);
+                memset(rd_recv, 0,   red_count);
+#endif
+
+#if defined(USE_CALIPER)
+                CALI_MARK_BEGIN(warmup_region_red);
+#endif
+                for (int i = 0; i < warmup; i++)
+                {
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+#endif
+                }
+
+#if defined(USE_CALIPER)
+                CALI_MARK_END(warmup_region_red);
+                CALI_MARK_BEGIN(region_label.c_str());
+#endif
+
+                double min_rtt = std::numeric_limits<double>::infinity();
+                double max_rtt = 0.0;
+                int iters = 0;
+
+                for(int i = 0; i < num_iterations; i++)
+                {
+                    MPI_Barrier(MPI_COMM_WORLD);
+                    double t0 = MPI_Wtime();
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(rd_h_send, rd_d_send, red_count, cudaMemcpyDeviceToHost));
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(rd_d_recv, rd_h_recv, red_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(rd_h_send, rd_d_send, red_count, hipMemcpyDeviceToHost);
+                    MPI_Reduce(rd_h_send, rd_h_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+                    hipMemcpy(rd_d_recv, rd_h_recv, red_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Reduce(rd_send, rd_recv, (int)red_count, MPI_CHAR, MPI_SUM, 0, MPI_COMM_WORLD);
+#endif
+                    double dt = MPI_Wtime() - t0;
+                    double iter_max = 0.0;
+                    MPI_Reduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+
+                    if(rank == 0)
+                    {
+                        red_total_time += iter_max;
+                        if(dt < min_rtt) min_rtt = dt;
+                        if(dt > max_rtt) max_rtt = dt;
+                        ++iters;
+
+                        double avg_rtt = (iters > 0) ? (red_total_time / iters) : 0.0;
+#if defined(USE_CALIPER)
+                        cali_set_string(comm_phase_attr, "reduce");
+                        cali_set_double(red_avg_time_sec_attr, avg_rtt);
+                        cali_set_double(red_max_time_sec_attr, max_rtt);
+                        cali_set_double(red_min_time_sec_attr, min_rtt);
+#endif
+                    }
+                }
+#if defined(USE_CALIPER)
+                CALI_MARK_END(region_label.c_str());
+#endif
+
+#if defined(USE_HIP)
+                free(rd_h_send);
+                free(rd_h_recv);
+                hipFree(rd_d_send);
+                hipFree(rd_d_recv);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFreeHost(rd_h_send));
+                cuda_check(cudaFreeHost(rd_h_recv));
+                cuda_check(cudaFree(rd_d_send));
+                cuda_check(cudaFree(rd_d_recv));
+#else
+                free(rd_send);
+                free(rd_recv);
+#endif
+            }
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // ===================== ALLREDUCE =====================
+        if (op == OpKind::Allreduce || op == OpKind::All)
+        {
+            for (int partner_rank : partners)
+            {
+                std::string region_label = region_names[partner_rank];
+
+                size_t ar_count = static_cast<size_t>(message);
+                if (ar_count > INT_MAX) {
+                    if (rank == 0) fprintf(stderr, "Allreduce count too large\n");
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+                int warmup = 1;
+                double ar_total_time = 0.0;
+
+#if defined(USE_CUDA)
+                char *ar_d_send=nullptr;
+                char *ar_d_recv=nullptr;
+                cuda_check(cudaMalloc((void**)&ar_d_send, ar_count));
+                cuda_check(cudaMalloc((void**)&ar_d_recv, ar_count));
+
+                char *ar_h_send=nullptr;
+                char *ar_h_recv=nullptr;
+                cuda_check(cudaMallocHost((void**)&ar_h_send, ar_count));
+                cuda_check(cudaMallocHost((void**)&ar_h_recv, ar_count));
+
+                fill_with_random_pattern(ar_h_send, ar_count);
+                memset(ar_h_recv, 0,   ar_count);
+
+                cuda_check(cudaMemcpy(ar_d_send, ar_h_send, ar_count, cudaMemcpyHostToDevice));
+                cuda_check(cudaMemset(ar_d_recv, 0,   ar_count));
+
+#elif defined(USE_HIP)
+                char *ar_d_send=nullptr;
+                char *ar_d_recv=nullptr;
+
+                hipError_t a_err1 = hipMalloc((void**)&ar_d_send, ar_count);
+                hipError_t a_err2 = hipMalloc((void**)&ar_d_recv, ar_count);
+
+                if (a_err1 != hipSuccess || a_err2 != hipSuccess) {
+                    fprintf(stderr, "HIP malloc failed: %s %s\n", hipGetErrorString(a_err1), hipGetErrorString(a_err2));
+                    MPI_Abort(MPI_COMM_WORLD, 1);
+                }
+
+                char *ar_h_send = (char*)malloc(ar_count);
+                char *ar_h_recv = (char*)malloc(ar_count);
+                fill_with_random_pattern(ar_h_send, ar_count);
+                memset(ar_h_recv, 0,   ar_count);
+
+                hipError_t a_cuerr1 = hipMemcpy(ar_d_send, ar_h_send, ar_count, hipMemcpyHostToDevice);
+                assert(a_cuerr1 == hipSuccess);
+                hipError_t a_cuerr2 = hipMemset(ar_d_recv, 0, ar_count);
+                assert(a_cuerr2 == hipSuccess);
+#else
+                char *ar_send = (char*)malloc(ar_count);
+                char *ar_recv = (char*)malloc(ar_count);
+                fill_with_random_pattern(ar_send, ar_count);
+                memset(ar_recv, 0,   ar_count);
+#endif
+
+#if defined(USE_CALIPER)
+                CALI_MARK_BEGIN(warmup_region_ar);
+#endif
+                for (int i = 0; i < warmup; i++)
+                {
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+#endif
+                }
+#if defined(USE_CALIPER)
+                CALI_MARK_END(warmup_region_ar);
+                CALI_MARK_BEGIN(region_label.c_str());
+#endif
+                double min_rtt = std::numeric_limits<double>::infinity();
+                double max_rtt = 0.0;
+                int iters = 0;
+
+                for(int i = 0; i < num_iterations; i++)
+                {
+                    MPI_Barrier(MPI_COMM_WORLD);
+                    double t0 = MPI_Wtime();
+#if defined(USE_CUDA)
+                    cuda_check(cudaMemcpy(ar_h_send, ar_d_send, ar_count, cudaMemcpyDeviceToHost));
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    cuda_check(cudaMemcpy(ar_d_recv, ar_h_recv, ar_count, cudaMemcpyHostToDevice));
+#elif defined(USE_HIP)
+                    hipMemcpy(ar_h_send, ar_d_send, ar_count, hipMemcpyDeviceToHost);
+                    MPI_Allreduce(ar_h_send, ar_h_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+                    hipMemcpy(ar_d_recv, ar_h_recv, ar_count, hipMemcpyHostToDevice);
+#else
+                    MPI_Allreduce(ar_send, ar_recv, (int)ar_count, MPI_CHAR, MPI_SUM, MPI_COMM_WORLD);
+#endif
+                    double dt = MPI_Wtime() - t0;
+                    double iter_max = 0.0;
+                    MPI_Allreduce(&dt, &iter_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
+                    if(rank == 0)
+                    {
+                        ar_total_time += iter_max;
+                        if(dt < min_rtt) min_rtt = dt;
+                        if(dt > max_rtt) max_rtt = dt;
+                        ++iters;
+
+                        double avg_rtt = (iters > 0) ? (ar_total_time / iters) : 0.0;
+#if defined(USE_CALIPER)
+                        cali_set_string(comm_phase_attr, "allreduce");
+                        cali_set_double(ar_avg_time_sec_attr, avg_rtt);
+                        cali_set_double(ar_max_time_sec_attr, max_rtt);
+                        cali_set_double(ar_min_time_sec_attr, min_rtt);
+#endif
+                    }
+                }
+#if defined(USE_CALIPER)
+                CALI_MARK_END(region_label.c_str());
+#endif
+
+#if defined(USE_HIP)
+                free(ar_h_send);
+                free(ar_h_recv);
+                hipFree(ar_d_send);
+                hipFree(ar_d_recv);
+#elif defined(USE_CUDA)
+                cuda_check(cudaFreeHost(ar_h_send));
+                cuda_check(cudaFreeHost(ar_h_recv));
+                cuda_check(cudaFree(ar_d_send));
+                cuda_check(cudaFree(ar_d_recv));
+#else
+                free(ar_send);
+                free(ar_recv);
+#endif
+            }
+        }
+
+#if defined(USE_CALIPER)
+        mgr[message].stop();
+#endif
+    }
+
+#if defined(USE_CALIPER)
+    if (rank == 0 && !all_comm_pairs.empty())
+    {
+        adiak::value("all_comm_pairs", all_comm_pairs);
+    }
+    for (auto &m : mgr)
+    {
+        m.second.flush();
+    }
+#endif
+
+    printf("rank %d\n", rank);
+    MPI_Finalize();
+    return 0;
+}


### PR DESCRIPTION
Last 10 months of changes since October:

- [ ] adding local communicator for all operations so it communicates correctly in same node same socket, same node different socket, 2 nodes, 4 nodes, and 8 nodes
- [ ] added window size in pingpong and bandwidth to replicate how OSU microbenchmarks makes
- [ ] random tests including having to comment out code for valgrind and reverts to make debugging easier (multiple commits of that)
- [ ] current loop is only on 1 message size, so I've been changing the message size manually on experiments (takes less time than running through all message sizes at once -> getting results faster with 1 message size (will change back to how it was originally of running through multiple message sizes once everything is ready)
- [ ] added debug statements (specifically on making sure all ranks go through everything correctly)
- [ ] fixed the min/max issue so it's not recording the avg time
- [ ] made the HIP areas GPU aware (may need to revert back?)
- [ ] added bandwidth operation